### PR TITLE
feat: Exclude test sources from CuiLogRecordPatternRecipe processing (Issue #6)

### DIFF
--- a/src/main/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipe.java
@@ -17,8 +17,10 @@ package de.cuioss.rewrite.logging;
 
 import de.cuioss.rewrite.util.BaseSuppressionVisitor;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.search.IsLikelyNotTest;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JLeftPadded;
@@ -66,7 +68,7 @@ public class CuiLogRecordPatternRecipe extends Recipe {
     }
 
     @Override public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new CuiLogRecordPatternVisitor();
+        return Preconditions.check(new IsLikelyNotTest(), new CuiLogRecordPatternVisitor());
     }
 
     @Override public List<Recipe> getRecipeList() {

--- a/src/test/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipeTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipeTest.java
@@ -17,8 +17,11 @@ package de.cuioss.rewrite.logging;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+
+import java.util.List;
 
 import static org.openrewrite.java.Assertions.java;
 
@@ -572,16 +575,37 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
             java(
                 """
                 import de.cuioss.tools.logging.CuiLogger;
-                
+
                 public class Example {
                     private static final CuiLogger LOGGER = new CuiLogger(Example.class);
-                    
+
                     public void test() {
                         // cui-rewrite:disable
                         LOGGER.info("Message without LogRecord");
                     }
                 }
                 """
+            )
+        );
+    }
+
+    @Test void shouldSkipTestSources() {
+        rewriteRun(
+            java(
+                """
+                import de.cuioss.tools.logging.CuiLogger;
+
+                public class MyTest {
+                    private static final CuiLogger LOGGER = new CuiLogger(MyTest.class);
+
+                    void testMethod() {
+                        // This would normally trigger the recipe, but should be skipped for test sources
+                        LOGGER.info("Test message without LogRecord");
+                    }
+                }
+                """,
+                s -> s.path("src/test/java/MyTest.java")
+                    .markers(JavaSourceSet.build("test", List.of()))
             )
         );
     }


### PR DESCRIPTION
## Summary

This PR implements issue #6 to exclude test sources from `CuiLogRecordPatternRecipe` processing. Test sources should not generate LogRecords, so the recipe now skips test code entirely.

### Changes:
- Added `Preconditions.check()` with `IsLikelyNotTest` precondition to the recipe visitor
- Test sources are now automatically excluded based on:
  - Source set name ("test" vs "main")
  - Presence of test framework annotations (JUnit, TestNG, etc.)
- Added test case `shouldSkipTestSources()` to verify test exclusion works correctly

### Technical Details:
The recipe now uses OpenRewrite's `IsLikelyNotTest` precondition which identifies test sources by examining:
1. The source set name containing "test"
2. Usage of test-related types from JUnit, TestNG, Hamcrest, Mockito, AssertJ, etc.

This ensures the recipe only processes production code where LogRecord patterns should be enforced.

## Test plan

- [x] All existing 165 tests pass
- [x] New test `shouldSkipTestSources()` verifies test sources are skipped
- [x] Clean install successful
- [x] Recipe correctly identifies and skips test sources using `JavaSourceSet` marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)