### PR TITLE
feat: Add suppression hints to all TODO markers (Issue #8)

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,5 +2,5 @@ name: cui-open-rewrite
 pages-reference: cui-open-rewrite
 sonar-project-key: cuioss_cui-open-rewrite
 release:
-  current-version: 1.0.7
+  current-version: 1.0.8
   next-version: 1.1.0-SNAPSHOT

--- a/src/main/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipe.java
@@ -121,14 +121,14 @@ public class CuiLogRecordPatternRecipe extends Recipe {
             switch (level) {
                 case INFO, WARN, ERROR, FATAL:
                     if (!usesLogRecord) {
-                        String message = "TODO: " + level + " needs LogRecord";
+                        String message = "TODO: " + level + " needs LogRecord. Suppress: // cui-rewrite:disable " + RECIPE_NAME;
                         return mi.withMarkers(mi.getMarkers().addIfAbsent(new SearchResult(UUID.randomUUID(), message)));
                     }
                     break;
 
                 case DEBUG, TRACE:
                     if (usesLogRecord) {
-                        String message = "TODO: " + level + " no LogRecord";
+                        String message = "TODO: " + level + " no LogRecord. Suppress: // cui-rewrite:disable " + RECIPE_NAME;
                         return mi.withMarkers(mi.getMarkers().addIfAbsent(new SearchResult(UUID.randomUUID(), message)));
                     }
                     break;

--- a/src/main/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipe.java
@@ -77,6 +77,8 @@ public class CuiLogRecordPatternRecipe extends Recipe {
 
     private static class CuiLogRecordPatternVisitor extends BaseSuppressionVisitor {
 
+        private static final String SUPPRESSION_HINT = ". Suppress: // cui-rewrite:disable " + RECIPE_NAME;
+
         public CuiLogRecordPatternVisitor() {
             super(RECIPE_NAME);
         }
@@ -121,14 +123,14 @@ public class CuiLogRecordPatternRecipe extends Recipe {
             switch (level) {
                 case INFO, WARN, ERROR, FATAL:
                     if (!usesLogRecord) {
-                        String message = "TODO: " + level + " needs LogRecord. Suppress: // cui-rewrite:disable " + RECIPE_NAME;
+                        String message = "TODO: " + level + " needs LogRecord" + SUPPRESSION_HINT;
                         return mi.withMarkers(mi.getMarkers().addIfAbsent(new SearchResult(UUID.randomUUID(), message)));
                     }
                     break;
 
                 case DEBUG, TRACE:
                     if (usesLogRecord) {
-                        String message = "TODO: " + level + " no LogRecord. Suppress: // cui-rewrite:disable " + RECIPE_NAME;
+                        String message = "TODO: " + level + " no LogRecord" + SUPPRESSION_HINT;
                         return mi.withMarkers(mi.getMarkers().addIfAbsent(new SearchResult(UUID.randomUUID(), message)));
                     }
                     break;

--- a/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
@@ -236,7 +236,7 @@ public class CuiLoggerStandardsRecipe extends Recipe {
 
         private J.MethodInvocation checkSystemStreams(J.MethodInvocation mi) {
             if (isSystemOutOrErr(mi)) {
-                return mi.withMarkers(mi.getMarkers().addIfAbsent(new SearchResult(randomId(), "TODO: Use CuiLogger")));
+                return mi.withMarkers(mi.getMarkers().addIfAbsent(new SearchResult(randomId(), "TODO: Use CuiLogger. Suppress: // cui-rewrite:disable " + RECIPE_NAME)));
             }
             return mi;
         }

--- a/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
@@ -85,6 +85,18 @@ public class InvalidExceptionUsageRecipe extends Recipe {
     private static class InvalidExceptionUsageVisitor extends JavaIsoVisitor<ExecutionContext> {
 
         /**
+         * Creates a task message with suppression hint for the given action and exception type.
+         *
+         * @param action the action being performed (e.g., "Catch", "Throw", "Use")
+         * @param simpleType the simple name of the exception type
+         * @return the complete task message with suppression hint
+         */
+        private String createTaskMessage(String action, String simpleType) {
+            return String.format("TODO: %s specific not %s. Suppress: // cui-rewrite:disable %s",
+                action, simpleType, RECIPE_NAME);
+        }
+
+        /**
          * Checks if a comment with the given message already exists near the element.
          * This prevents duplicate markers when recipes run multiple times.
          * We check for the specific format that OpenRewrite uses: "/*~~(...)~~>* /"
@@ -214,7 +226,7 @@ public class InvalidExceptionUsageRecipe extends Recipe {
 
                 if (fqType != null && GENERIC_EXCEPTION_TYPES.contains(fqType.getFullyQualifiedName())) {
                     String simpleType = fqType.getClassName();
-                    String taskMessage = "TODO: Catch specific not " + simpleType + ". Suppress: // cui-rewrite:disable " + RECIPE_NAME;
+                    String taskMessage = createTaskMessage("Catch", simpleType);
 
                     // Check if this comment already exists (from a previous run)
                     if (hasTaskComment(c, taskMessage) || c.getMarkers().findFirst(SearchResult.class).isPresent()) {
@@ -243,7 +255,7 @@ public class InvalidExceptionUsageRecipe extends Recipe {
 
                 if (fqType != null && GENERIC_EXCEPTION_TYPES.contains(fqType.getFullyQualifiedName())) {
                     String simpleType = fqType.getClassName();
-                    String taskMessage = "TODO: Throw specific not " + simpleType + ". Suppress: // cui-rewrite:disable " + RECIPE_NAME;
+                    String taskMessage = createTaskMessage("Throw", simpleType);
 
                     // Check if this comment already exists (from a previous run)
                     if (hasTaskComment(t, taskMessage) || t.getMarkers().findFirst(SearchResult.class).isPresent()) {
@@ -276,7 +288,7 @@ public class InvalidExceptionUsageRecipe extends Recipe {
 
             if (fqType != null && GENERIC_EXCEPTION_TYPES.contains(fqType.getFullyQualifiedName())) {
                 String simpleType = fqType.getClassName();
-                String taskMessage = "TODO: Use specific not " + simpleType + ". Suppress: // cui-rewrite:disable " + RECIPE_NAME;
+                String taskMessage = createTaskMessage("Use", simpleType);
 
                 // Check if this comment already exists (from a previous run)
                 if (hasTaskComment(nc, taskMessage) || nc.getMarkers().findFirst(SearchResult.class).isPresent()) {

--- a/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
@@ -214,7 +214,7 @@ public class InvalidExceptionUsageRecipe extends Recipe {
 
                 if (fqType != null && GENERIC_EXCEPTION_TYPES.contains(fqType.getFullyQualifiedName())) {
                     String simpleType = fqType.getClassName();
-                    String taskMessage = "TODO: Catch specific not " + simpleType;
+                    String taskMessage = "TODO: Catch specific not " + simpleType + ". Suppress: // cui-rewrite:disable " + RECIPE_NAME;
 
                     // Check if this comment already exists (from a previous run)
                     if (hasTaskComment(c, taskMessage) || c.getMarkers().findFirst(SearchResult.class).isPresent()) {
@@ -243,7 +243,7 @@ public class InvalidExceptionUsageRecipe extends Recipe {
 
                 if (fqType != null && GENERIC_EXCEPTION_TYPES.contains(fqType.getFullyQualifiedName())) {
                     String simpleType = fqType.getClassName();
-                    String taskMessage = "TODO: Throw specific not " + simpleType;
+                    String taskMessage = "TODO: Throw specific not " + simpleType + ". Suppress: // cui-rewrite:disable " + RECIPE_NAME;
 
                     // Check if this comment already exists (from a previous run)
                     if (hasTaskComment(t, taskMessage) || t.getMarkers().findFirst(SearchResult.class).isPresent()) {
@@ -276,7 +276,7 @@ public class InvalidExceptionUsageRecipe extends Recipe {
 
             if (fqType != null && GENERIC_EXCEPTION_TYPES.contains(fqType.getFullyQualifiedName())) {
                 String simpleType = fqType.getClassName();
-                String taskMessage = "TODO: Use specific not " + simpleType;
+                String taskMessage = "TODO: Use specific not " + simpleType + ". Suppress: // cui-rewrite:disable " + RECIPE_NAME;
 
                 // Check if this comment already exists (from a previous run)
                 if (hasTaskComment(nc, taskMessage) || nc.getMarkers().findFirst(SearchResult.class).isPresent()) {

--- a/src/test/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipeReproduceTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipeReproduceTest.java
@@ -87,7 +87,7 @@ class CuiLogRecordPatternRecipeReproduceTest implements RewriteTest {
 
                     public void testMethod() {
                         String name = getName(); // This should not be processed as a log level
-                        /*~~(TODO: INFO needs LogRecord)~~>*/LOG.info("Test message"); // This should be processed but shouldn't fail
+                        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOG.info("Test message"); // This should be processed but shouldn't fail
                     }
 
                     private String getName() {

--- a/src/test/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipeTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipeTest.java
@@ -108,7 +108,7 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
 
                     void method() {
                         String username = "john";
-                        /*~~(TODO: INFO needs LogRecord)~~>*/LOGGER.info("User %s logged in", username);
+                        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("User %s logged in", username);
                     }
                 }
                 """
@@ -137,7 +137,7 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
                     private static final CuiLogger LOGGER = new CuiLogger(Test.class);
 
                     void method(Exception e) {
-                        /*~~(TODO: ERROR needs LogRecord)~~>*/LOGGER.error(e, "Error occurred: %s", e.getMessage());
+                        /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.error(e, "Error occurred: %s", e.getMessage());
                     }
                 }
                 """
@@ -166,7 +166,7 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
                     private static final CuiLogger LOGGER = new CuiLogger(Test.class);
 
                     void method() {
-                        /*~~(TODO: WARN needs LogRecord)~~>*/LOGGER.warn("Something is wrong");
+                        /*~~(TODO: WARN needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.warn("Something is wrong");
                     }
                 }
                 """
@@ -205,7 +205,7 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
                         .build();
 
                     void method() {
-                        /*~~(TODO: DEBUG no LogRecord)~~>*/LOGGER.debug(DEBUG_MESSAGE.format("value"));
+                        /*~~(TODO: DEBUG no LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.debug(DEBUG_MESSAGE.format("value"));
                     }
                 }
                 """
@@ -244,7 +244,7 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
                         .build();
 
                     void method() {
-                        /*~~(TODO: TRACE no LogRecord)~~>*/LOGGER.trace(TRACE_MESSAGE.format());
+                        /*~~(TODO: TRACE no LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.trace(TRACE_MESSAGE.format());
                     }
                 }
                 """

--- a/src/test/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipeTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipeTest.java
@@ -208,8 +208,8 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
                 """
                 class Test {
                     void method() {
-                        /*~~(TODO: Use CuiLogger)~~>*/System.out.println("Should not use System.out");
-                        /*~~(TODO: Use CuiLogger)~~>*/System.err.println("Should not use System.err");
+                        /*~~(TODO: Use CuiLogger. Suppress: // cui-rewrite:disable CuiLoggerStandardsRecipe)~~>*/System.out.println("Should not use System.out");
+                        /*~~(TODO: Use CuiLogger. Suppress: // cui-rewrite:disable CuiLoggerStandardsRecipe)~~>*/System.err.println("Should not use System.err");
                     }
                 }
                 """

--- a/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeIssue5Test.java
+++ b/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeIssue5Test.java
@@ -47,7 +47,7 @@ class InvalidExceptionUsageRecipeIssue5Test implements RewriteTest {
                     void test() {
                         try {
                             doSomething();
-                        } /*~~(TODO: Catch specific not Exception)~~>*/catch (Exception e) {
+                        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
                             e.printStackTrace();
                         }
                     }
@@ -79,7 +79,7 @@ class InvalidExceptionUsageRecipeIssue5Test implements RewriteTest {
                 """
                 class Test {
                     void test() throws Exception {
-                        /*~~(TODO: Throw specific not Exception)~~>*/throw new Exception("test");
+                        /*~~(TODO: Throw specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new Exception("test");
                     }
                 }
                 """

--- a/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeSuppressionTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeSuppressionTest.java
@@ -95,7 +95,7 @@ class InvalidExceptionUsageRecipeSuppressionTest implements RewriteTest {
                     void method() {
                         try {
                             doSomething();
-                        } /*~~(TODO: Catch specific not RuntimeException)~~>*/catch (RuntimeException e) {
+                        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
                             handleException(e);
                         }
                     }
@@ -222,7 +222,7 @@ class InvalidExceptionUsageRecipeSuppressionTest implements RewriteTest {
                         try {
                             doSomething();
                             // cui-rewrite:disable SomeOtherRecipe
-                        } /*~~(TODO: Catch specific not Exception)~~>*/catch (Exception e) {
+                        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
                             handleException(e);
                         }
                     }

--- a/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeTest.java
@@ -53,13 +53,13 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     void test() {
                         try {
                             doSomething();
-                        } /*~~(TODO: Catch specific not Exception)~~>*/catch (Exception e) {
+                        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
                             e.printStackTrace();
                         }
                     }
 
                     void doSomething() throws Exception {
-                        /*~~(TODO: Throw specific not Exception)~~>*/throw new Exception("test");
+                        /*~~(TODO: Throw specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new Exception("test");
                     }
                 }
                 """
@@ -90,7 +90,7 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     void test() {
                         try {
                             doSomething();
-                        } /*~~(TODO: Catch specific not RuntimeException)~~>*/catch (RuntimeException e) {
+                        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
                             e.printStackTrace();
                         }
                     }
@@ -127,7 +127,7 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     void test() {
                         try {
                             doSomething();
-                        } /*~~(TODO: Catch specific not Throwable)~~>*/catch (Throwable t) {
+                        } /*~~(TODO: Catch specific not Throwable. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Throwable t) {
                             t.printStackTrace();
                         }
                     }
@@ -154,7 +154,7 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                 """
                 class Test {
                     void test() throws Exception {
-                        /*~~(TODO: Throw specific not Exception)~~>*/throw new Exception("Bad practice");
+                        /*~~(TODO: Throw specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new Exception("Bad practice");
                     }
                 }
                 """
@@ -175,7 +175,7 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                 """
                 class Test {
                     void test() {
-                        /*~~(TODO: Throw specific not RuntimeException)~~>*/throw new RuntimeException("Bad practice");
+                        /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException("Bad practice");
                     }
                 }
                 """
@@ -197,7 +197,7 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                 """
                 class Test {
                     void test() {
-                        Exception e = /*~~(TODO: Use specific not Exception)~~>*/new Exception("Bad practice");
+                        Exception e = /*~~(TODO: Use specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/new Exception("Bad practice");
                         // Do something with e
                     }
                 }
@@ -261,7 +261,7 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                             doSomething();
                         } catch (IOException e) {
                             // Handle specific exception
-                        } /*~~(TODO: Catch specific not Exception)~~>*/catch (Exception e) {
+                        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
                             // Generic catch as fallback
                         }
                     }
@@ -353,10 +353,10 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                         try {
                             try {
                                 doSomething();
-                            } /*~~(TODO: Catch specific not RuntimeException)~~>*/catch (RuntimeException re) {
-                                /*~~(TODO: Throw specific not Exception)~~>*/throw new Exception("Wrapping", re);
+                            } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException re) {
+                                /*~~(TODO: Throw specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new Exception("Wrapping", re);
                             }
-                        } /*~~(TODO: Catch specific not Exception)~~>*/catch (Exception e) {
+                        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
                             e.printStackTrace();
                         }
                     }
@@ -400,8 +400,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                         Supplier<String> supplier = () -> {
                             try {
                                 return doSomething();
-                            } /*~~(TODO: Catch specific not Exception)~~>*/catch (Exception e) {
-                                /*~~(TODO: Throw specific not RuntimeException)~~>*/throw new RuntimeException(e);
+                            } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+                                /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException(e);
                             }
                         };
                     }
@@ -480,7 +480,7 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                 """
                 class Test {
                     void test() throws Exception {
-                        /*~~(TODO: Throw specific not Exception)~~>*/throw new Exception("Bad practice");
+                        /*~~(TODO: Throw specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new Exception("Bad practice");
                     }
                 }
                 """
@@ -501,7 +501,7 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                 """
                 class Test {
                     Exception createException() {
-                        return /*~~(TODO: Use specific not RuntimeException)~~>*/new RuntimeException("Assignment case");
+                        return /*~~(TODO: Use specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/new RuntimeException("Assignment case");
                     }
                 }
                 """
@@ -526,7 +526,7 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                 """
                 class Test {
                     void test() {
-                        handleException(/*~~(TODO: Use specific not Exception)~~>*/new Exception("Parameter case"));
+                        handleException(/*~~(TODO: Use specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/new Exception("Parameter case"));
                     }
                     
                     void handleException(Exception e) {
@@ -561,7 +561,7 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     }
 
                     void notSuppressedMethod() throws Exception {
-                        /*~~(TODO: Throw specific not Exception)~~>*/throw new Exception("Not suppressed");
+                        /*~~(TODO: Throw specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new Exception("Not suppressed");
                     }
                 }
                 """
@@ -592,8 +592,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     void test() {
                         try {
                             doSomething();
-                        } /*~~(TODO: Catch specific not Throwable)~~>*/catch (Throwable t) {
-                            /*~~(TODO: Throw specific not Throwable)~~>*/throw new Throwable("Wrapping", t);
+                        } /*~~(TODO: Catch specific not Throwable. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Throwable t) {
+                            /*~~(TODO: Throw specific not Throwable. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new Throwable("Wrapping", t);
                         }
                     }
 
@@ -629,13 +629,13 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     static {
                         try {
                             initialize();
-                        } /*~~(TODO: Catch specific not Exception)~~>*/catch (Exception e) {
-                            /*~~(TODO: Throw specific not RuntimeException)~~>*/throw new RuntimeException("Static init failed", e);
+                        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+                            /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException("Static init failed", e);
                         }
                     }
 
                     static void initialize() throws Exception {
-                        /*~~(TODO: Throw specific not Exception)~~>*/throw new Exception("Init error");
+                        /*~~(TODO: Throw specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new Exception("Init error");
                     }
                 }
                 """
@@ -667,7 +667,7 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     void test() {
                         try {
                             doSomething();
-                        } /*~~(TODO: Catch specific not Exception)~~>*/catch (Exception e) {
+                        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
                             e.printStackTrace();
                         }
                     }
@@ -695,7 +695,7 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                 """
                 class Test {
                     void test() throws Exception {
-                        /*~~(TODO: Throw specific not Exception)~~>*/throw new Exception("Bad practice");
+                        /*~~(TODO: Throw specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new Exception("Bad practice");
                     }
                 }
                 """
@@ -717,7 +717,7 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                 """
                 class Test {
                     Exception createException() {
-                        return /*~~(TODO: Use specific not RuntimeException)~~>*/new RuntimeException("Assignment case");
+                        return /*~~(TODO: Use specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/new RuntimeException("Assignment case");
                     }
                 }
                 """
@@ -750,8 +750,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     void test() {
                         try (FileInputStream fis = new FileInputStream("test.txt")) {
                             // Use resource
-                        } /*~~(TODO: Catch specific not Exception)~~>*/catch (Exception e) {
-                            /*~~(TODO: Throw specific not RuntimeException)~~>*/throw new RuntimeException(e);
+                        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+                            /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException(e);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

This PR implements [Issue #8](https://github.com/cuioss/cui-open-rewrite/issues/8) by adding concrete suppression hints to all TODO markers inserted by OpenRewrite recipes. This enhancement helps developers quickly understand how to suppress unwanted markers without consulting documentation.

## Changes

### Recipe Enhancements

**InvalidExceptionUsageRecipe:**
- Updated catch block markers to include suppression hint
- Updated throw statement markers to include suppression hint  
- Updated exception creation markers to include suppression hint

**CuiLoggerStandardsRecipe:**
- Added suppression hint to System.out/err usage markers

**CuiLogRecordPatternRecipe:**
- Added suppression hints to LogRecord required markers (INFO/WARN/ERROR/FATAL)
- Added suppression hints to LogRecord forbidden markers (DEBUG/TRACE)

### Example Change

**Before:**
```java
/*~~(TODO: Catch specific not Exception)~~>*/catch (Exception e)
```

**After:**
```java
/*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e)
```

### Test Updates

All test files have been updated to reflect the new marker format with suppression hints.

## Testing

- ✅ All 165 tests pass
- ✅ Duplicate marker prevention verified (Issue #5)
- ✅ Clean build with `mvn clean install`

## Implementation Details

The suppression hint follows the format: `Suppress: // cui-rewrite:disable <RecipeName>`

This provides developers with the exact comment needed to suppress the marker, making it clear that:
1. They can suppress the marker if intentional
2. The exact syntax to use
3. Which recipe is generating the marker

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)