### PR TITLE
fix: AnnotationNewlineFormat now persists through AutoFormat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <maven.jar.plugin.automatic.module.name>de.cuioss.rewrite</maven.jar.plugin.automatic.module.name>
         <openrewrite.version>8.61.2</openrewrite.version>
         <openrewrite.maven.version>6.17.0</openrewrite.maven.version>
+        <cui-open-rewrite.version>1.1.0-SNAPSHOT</cui-open-rewrite.version>
     </properties>
     <dependencies>
         <!-- OpenRewrite Core -->

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
     <artifactId>cui-open-rewrite</artifactId>
     <version>1.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
-    <name>cui java module template</name>
-    <description> OpenRewrite recipes for cuioss projects.
+    <name>cui open-rewrite</name>
+    <description>OpenRewrite recipes for cuioss projects.
     </description>
     <url>https://github.com/cuioss/cui-open-rewrite/</url>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
         <maven.jar.plugin.automatic.module.name>de.cuioss.rewrite</maven.jar.plugin.automatic.module.name>
         <openrewrite.version>8.61.2</openrewrite.version>
         <openrewrite.maven.version>6.17.0</openrewrite.maven.version>
-        <cui-open-rewrite.version>1.1.0-SNAPSHOT</cui-open-rewrite.version>
     </properties>
     <dependencies>
         <!-- OpenRewrite Core -->

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.cuioss</groupId>
         <artifactId>cui-java-parent</artifactId>
-        <version>1.1.4</version>
+        <version>1.2.5</version>
         <relativePath />
     </parent>
     <groupId>de.cuioss.rewrite</groupId>
@@ -30,6 +30,7 @@
         <system>GitHub Issues</system>
     </issueManagement>
     <properties>
+        <maven.compiler.release>21</maven.compiler.release>
         <maven.jar.plugin.automatic.module.name>de.cuioss.rewrite</maven.jar.plugin.automatic.module.name>
         <openrewrite.version>8.61.2</openrewrite.version>
         <openrewrite.maven.version>6.17.0</openrewrite.maven.version>

--- a/src/main/java/de/cuioss/rewrite/format/AnnotationNewlineFormat.java
+++ b/src/main/java/de/cuioss/rewrite/format/AnnotationNewlineFormat.java
@@ -154,11 +154,10 @@ public class AnnotationNewlineFormat extends Recipe {
 
             // Check if the last annotation has a trailing inline comment
             // If so, we should not reformat to preserve the comment position
-            if (!cd.getLeadingAnnotations().isEmpty() && !cd.getModifiers().isEmpty()) {
-                if (hasInlineComment(cd.getModifiers().getFirst().getPrefix())) {
-                    return false;
-                }
+            if (!cd.getLeadingAnnotations().isEmpty() && !cd.getModifiers().isEmpty() && hasInlineComment(cd.getModifiers().getFirst().getPrefix())) {
+                return false;
             }
+
 
             // Check if there needs to be a newline after annotations
             if (!cd.getModifiers().isEmpty()) {
@@ -168,6 +167,7 @@ public class AnnotationNewlineFormat extends Recipe {
             return false;
         }
 
+        @SuppressWarnings("java:S3776")
         private boolean needsMethodFormatting(J.MethodDeclaration md) {
             // Check if annotations need to be on separate lines
             if (md.getLeadingAnnotations().size() > 1) {
@@ -202,6 +202,7 @@ public class AnnotationNewlineFormat extends Recipe {
             }
         }
 
+        @SuppressWarnings("java:S3776")
         private boolean needsFieldFormatting(J.VariableDeclarations vd) {
             // Check if annotations need to be on separate lines
             if (vd.getLeadingAnnotations().size() > 1) {
@@ -362,15 +363,6 @@ public class AnnotationNewlineFormat extends Recipe {
             }
 
             return modifiers;
-        }
-
-        private String getIndentationFromPrefix(Space space) {
-            String whitespace = space.getWhitespace();
-            int lastNewline = whitespace.lastIndexOf('\n');
-            if (lastNewline >= 0) {
-                return whitespace.substring(lastNewline + 1);
-            }
-            return whitespace;
         }
 
         /**

--- a/src/main/java/de/cuioss/rewrite/format/AnnotationNewlineFormat.java
+++ b/src/main/java/de/cuioss/rewrite/format/AnnotationNewlineFormat.java
@@ -144,8 +144,9 @@ public class AnnotationNewlineFormat extends Recipe {
                 }
             }
 
-            // For single annotation: if there's an inline comment, don't reformat
-            if (cd.getLeadingAnnotations().size() == 1 && !cd.getModifiers().isEmpty()) {
+            // Check if the last annotation has a trailing inline comment
+            // If so, we should not reformat to preserve the comment position
+            if (!cd.getLeadingAnnotations().isEmpty() && !cd.getModifiers().isEmpty()) {
                 if (hasInlineComment(cd.getModifiers().getFirst().getPrefix())) {
                     return false;
                 }
@@ -169,8 +170,9 @@ public class AnnotationNewlineFormat extends Recipe {
                 }
             }
 
-            // For single annotation: if there's an inline comment, don't reformat
-            if (md.getLeadingAnnotations().size() == 1) {
+            // Check if the last annotation has a trailing inline comment
+            // If so, we should not reformat to preserve the comment position
+            if (!md.getLeadingAnnotations().isEmpty()) {
                 Space nextElementPrefix = null;
                 if (!md.getModifiers().isEmpty()) {
                     nextElementPrefix = md.getModifiers().getFirst().getPrefix();
@@ -202,8 +204,9 @@ public class AnnotationNewlineFormat extends Recipe {
                 }
             }
 
-            // For single annotation: if there's an inline comment, don't reformat
-            if (vd.getLeadingAnnotations().size() == 1) {
+            // Check if the last annotation has a trailing inline comment
+            // If so, we should not reformat to preserve the comment position
+            if (!vd.getLeadingAnnotations().isEmpty()) {
                 Space nextElementPrefix = null;
                 if (!vd.getModifiers().isEmpty()) {
                     nextElementPrefix = vd.getModifiers().getFirst().getPrefix();

--- a/src/main/java/de/cuioss/rewrite/format/AnnotationNewlineFormat.java
+++ b/src/main/java/de/cuioss/rewrite/format/AnnotationNewlineFormat.java
@@ -35,23 +35,28 @@ public class AnnotationNewlineFormat extends Recipe {
 
     public static final String RECIPE_NAME = "AnnotationNewlineFormat";
 
-    @Override public String getDisplayName() {
+    @Override
+    public String getDisplayName() {
         return "Format annotations with newlines";
     }
 
-    @Override public String getDescription() {
+    @Override
+    public String getDescription() {
         return "Ensures type-level and method-level annotations are on separate lines.";
     }
 
-    @Override public Set<String> getTags() {
+    @Override
+    public Set<String> getTags() {
         return Set.of("CUI", "format", "annotation");
     }
 
-    @Override public Duration getEstimatedEffortPerOccurrence() {
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
         return Duration.ofMinutes(1);
     }
 
-    @Override public TreeVisitor<?, ExecutionContext> getVisitor() {
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new AnnotationNewlineFormatVisitor();
     }
 
@@ -59,7 +64,8 @@ public class AnnotationNewlineFormat extends Recipe {
 
         private static final CuiLogger LOGGER = new CuiLogger(AnnotationNewlineFormatVisitor.class);
 
-        @Override public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
             // Check for suppression comments
             if (RecipeSuppressionUtil.isSuppressed(getCursor(), RECIPE_NAME)) {
                 LOGGER.debug("Skipping class %s due to suppression", classDecl.getSimpleName());
@@ -83,7 +89,8 @@ public class AnnotationNewlineFormat extends Recipe {
             return cd;
         }
 
-        @Override public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
             // Check for suppression comments
             if (RecipeSuppressionUtil.isSuppressed(getCursor(), RECIPE_NAME)) {
                 LOGGER.debug("Skipping method %s due to suppression", method.getSimpleName());
@@ -107,7 +114,8 @@ public class AnnotationNewlineFormat extends Recipe {
             return md;
         }
 
-        @Override public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+        @Override
+        public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
             // Check for suppression only on fields
             if (isFieldDeclaration() && RecipeSuppressionUtil.isSuppressed(getCursor(), RECIPE_NAME)) {
                 return multiVariable;

--- a/src/main/java/de/cuioss/rewrite/format/AnnotationNewlineFormat.java
+++ b/src/main/java/de/cuioss/rewrite/format/AnnotationNewlineFormat.java
@@ -237,8 +237,9 @@ public class AnnotationNewlineFormat extends Recipe {
             List<J.Annotation> result = new ArrayList<>();
             result.add(annotations.getFirst()); // Keep first annotation as-is
 
-            // Get base indentation from first annotation
-            String baseIndent = getIndentationFromPrefix(annotations.getFirst().getPrefix());
+            // Get base indentation from parent context, not from first annotation
+            // This is critical: inline annotations don't have parent indentation in their prefix
+            String baseIndent = getProperIndentation();
 
             // Format subsequent annotations
             for (int i = 1; i < annotations.size(); i++) {

--- a/src/main/java/de/cuioss/rewrite/format/AnnotationNewlineFormat.java
+++ b/src/main/java/de/cuioss/rewrite/format/AnnotationNewlineFormat.java
@@ -62,7 +62,7 @@ public class AnnotationNewlineFormat extends Recipe {
         @Override public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
             // Check for suppression comments
             if (RecipeSuppressionUtil.isSuppressed(getCursor(), RECIPE_NAME)) {
-                LOGGER.debug("Skipping class {} due to suppression", classDecl.getSimpleName());
+                LOGGER.debug("Skipping class %s due to suppression", classDecl.getSimpleName());
                 return classDecl;
             }
 
@@ -73,7 +73,7 @@ public class AnnotationNewlineFormat extends Recipe {
                 return cd;
             }
 
-            LOGGER.debug("Formatting annotations for class: {}", cd.getSimpleName());
+            LOGGER.debug("Formatting annotations for class: %s", cd.getSimpleName());
             // Format annotations - ensure each on separate line
             cd = cd.withLeadingAnnotations(formatAnnotationList(cd.getLeadingAnnotations()));
 
@@ -86,7 +86,7 @@ public class AnnotationNewlineFormat extends Recipe {
         @Override public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
             // Check for suppression comments
             if (RecipeSuppressionUtil.isSuppressed(getCursor(), RECIPE_NAME)) {
-                LOGGER.debug("Skipping method {} due to suppression", method.getSimpleName());
+                LOGGER.debug("Skipping method %s due to suppression", method.getSimpleName());
                 return method;
             }
 
@@ -97,7 +97,7 @@ public class AnnotationNewlineFormat extends Recipe {
                 return md;
             }
 
-            LOGGER.debug("Formatting annotations for method: {}", md.getSimpleName());
+            LOGGER.debug("Formatting annotations for method: %s", md.getSimpleName());
             // Format annotations - ensure each on separate line
             md = md.withLeadingAnnotations(formatAnnotationList(md.getLeadingAnnotations()));
 
@@ -233,7 +233,7 @@ public class AnnotationNewlineFormat extends Recipe {
                 return annotations;
             }
 
-            LOGGER.debug("Formatting {} annotations to ensure each is on a separate line", annotations.size());
+            LOGGER.debug("Formatting %s annotations to ensure each is on a separate line", annotations.size());
             List<J.Annotation> result = new ArrayList<>();
             result.add(annotations.getFirst()); // Keep first annotation as-is
 
@@ -373,8 +373,8 @@ public class AnnotationNewlineFormat extends Recipe {
             Cursor cursor = getCursor();
             Object value = cursor.getValue();
 
-            if (value instanceof J) {
-                Space prefix = ((J) value).getPrefix();
+            if (value instanceof J j) {
+                Space prefix = j.getPrefix();
                 String whitespace = prefix.getWhitespace();
                 int lastNewline = whitespace.lastIndexOf('\n');
                 if (lastNewline >= 0) {

--- a/src/main/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipe.java
@@ -48,30 +48,36 @@ public class CuiLogRecordPatternRecipe extends Recipe {
         "https://gitingest.com/github.com/cuioss/cui-llm-rules/tree/main/standards/logging/implementation-guide.adoc";
     public static final String RECIPE_NAME = "CuiLogRecordPatternRecipe";
 
-    @Override public String getDisplayName() {
+    @Override
+    public String getDisplayName() {
         return "CUI LogRecord pattern validation";
     }
 
-    @Override public String getDescription() {
+    @Override
+    public String getDescription() {
         return "Enforces proper usage of LogRecord pattern: " +
             "mandatory for INFO/WARN/ERROR/FATAL levels, " +
             "forbidden for DEBUG/TRACE levels. " +
             "See: " + PATTERN_DOC_URL + ".";
     }
 
-    @Override public Set<String> getTags() {
+    @Override
+    public Set<String> getTags() {
         return Set.of("CUI", "logging", "LogRecord", "standards");
     }
 
-    @Override public Duration getEstimatedEffortPerOccurrence() {
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
         return Duration.ofMinutes(3);
     }
 
-    @Override public TreeVisitor<?, ExecutionContext> getVisitor() {
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new IsLikelyNotTest(), new CuiLogRecordPatternVisitor());
     }
 
-    @Override public List<Recipe> getRecipeList() {
+    @Override
+    public List<Recipe> getRecipeList() {
         return List.of();
     }
 
@@ -83,7 +89,8 @@ public class CuiLogRecordPatternRecipe extends Recipe {
             super(RECIPE_NAME);
         }
 
-        @Override public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
 
             // Check if suppressed

--- a/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
@@ -41,11 +41,13 @@ public class CuiLoggerStandardsRecipe extends Recipe {
     private static final String LOGGER_NAME = "LOGGER";
     public static final String RECIPE_NAME = "CuiLoggerStandardsRecipe";
 
-    @Override public String getDisplayName() {
+    @Override
+    public String getDisplayName() {
         return "CUI logger standards";
     }
 
-    @Override public String getDescription() {
+    @Override
+    public String getDescription() {
         return """
             Enforces CUI-specific logging standards including proper logger naming, \
             string substitution patterns, exception parameter position, parameter validation, \
@@ -53,19 +55,23 @@ public class CuiLoggerStandardsRecipe extends Recipe {
             and detection of System.out/System.err usage.""";
     }
 
-    @Override public Set<String> getTags() {
+    @Override
+    public Set<String> getTags() {
         return Set.of("CUI", "logging", "standards");
     }
 
-    @Override public Duration getEstimatedEffortPerOccurrence() {
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
         return Duration.ofMinutes(5);
     }
 
-    @Override public TreeVisitor<?, ExecutionContext> getVisitor() {
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new CuiLoggerStandardsVisitor();
     }
 
-    @Override public List<Recipe> getRecipeList() {
+    @Override
+    public List<Recipe> getRecipeList() {
         return List.of();
     }
 
@@ -79,7 +85,8 @@ public class CuiLoggerStandardsRecipe extends Recipe {
             return UUID.randomUUID();
         }
 
-        @Override public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations variableDecls, ExecutionContext ctx) {
+        @Override
+        public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations variableDecls, ExecutionContext ctx) {
             J.VariableDeclarations vd = super.visitVariableDeclarations(variableDecls, ctx);
 
             // Only process field declarations, not local variables
@@ -207,7 +214,8 @@ public class CuiLoggerStandardsRecipe extends Recipe {
         }
 
 
-        @Override public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
 
             if (isSuppressed()) {

--- a/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
@@ -46,10 +46,11 @@ public class CuiLoggerStandardsRecipe extends Recipe {
     }
 
     @Override public String getDescription() {
-        return "Enforces CUI-specific logging standards including proper logger naming, " +
-            "string substitution patterns, exception parameter position, parameter validation, " +
-            "LogRecord pattern usage for INFO/WARN/ERROR levels, " +
-            "and detection of System.out/System.err usage.";
+        return """
+            Enforces CUI-specific logging standards including proper logger naming, \
+            string substitution patterns, exception parameter position, parameter validation, \
+            LogRecord pattern usage for INFO/WARN/ERROR levels, \
+            and detection of System.out/System.err usage.""";
     }
 
     @Override public Set<String> getTags() {

--- a/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
@@ -346,7 +346,8 @@ public class CuiLoggerStandardsRecipe extends Recipe {
             }
 
             if (placeholderCount != paramCount) {
-                String message = "%d placeholders, %d params".formatted(placeholderCount, paramCount);
+                String message = "TODO: %d placeholders, %d params. Suppress: // cui-rewrite:disable %s"
+                    .formatted(placeholderCount, paramCount, RECIPE_NAME);
                 return mi.withMarkers(mi.getMarkers().addIfAbsent(new SearchResult(randomId(), message)));
             }
 

--- a/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
@@ -16,6 +16,7 @@
 package de.cuioss.rewrite.logging;
 
 import de.cuioss.rewrite.util.BaseSuppressionVisitor;
+import de.cuioss.rewrite.util.RecipeMarkerUtil;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
@@ -224,7 +225,7 @@ public class CuiLoggerStandardsRecipe extends Recipe {
 
             // Check for System.out/err usage
             mi = checkSystemStreams(mi);
-            if (mi.getMarkers().findFirst(SearchResult.class).isPresent()) {
+            if (RecipeMarkerUtil.hasSearchResultMarker(mi)) {
                 return mi;
             }
 
@@ -245,7 +246,8 @@ public class CuiLoggerStandardsRecipe extends Recipe {
 
         private J.MethodInvocation checkSystemStreams(J.MethodInvocation mi) {
             if (isSystemOutOrErr(mi)) {
-                return mi.withMarkers(mi.getMarkers().addIfAbsent(new SearchResult(randomId(), "TODO: Use CuiLogger. Suppress: // cui-rewrite:disable " + RECIPE_NAME)));
+                String message = RecipeMarkerUtil.createTaskMessage("Use CuiLogger", RECIPE_NAME);
+                return mi.withMarkers(mi.getMarkers().addIfAbsent(new SearchResult(randomId(), message)));
             }
             return mi;
         }
@@ -263,7 +265,7 @@ public class CuiLoggerStandardsRecipe extends Recipe {
 
             // Validate parameter count
             mi = validateParameterCount(mi, context);
-            if (mi.getMarkers().findFirst(SearchResult.class).isPresent()) {
+            if (RecipeMarkerUtil.hasSearchResultMarker(mi)) {
                 return mi;
             }
 
@@ -355,8 +357,8 @@ public class CuiLoggerStandardsRecipe extends Recipe {
             }
 
             if (placeholderCount != paramCount) {
-                String message = "TODO: %d placeholders, %d params. Suppress: // cui-rewrite:disable %s"
-                    .formatted(placeholderCount, paramCount, RECIPE_NAME);
+                String action = "%d placeholders, %d params".formatted(placeholderCount, paramCount);
+                String message = RecipeMarkerUtil.createTaskMessage(action, RECIPE_NAME);
                 return mi.withMarkers(mi.getMarkers().addIfAbsent(new SearchResult(randomId(), message)));
             }
 

--- a/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
@@ -425,10 +425,12 @@ public class CuiLoggerStandardsRecipe extends Recipe {
 
 
         private static class LoggerCallContext {
-            @Nullable Expression messageArg;
+            @Nullable
+            Expression messageArg;
             int messageArgIndex;
             boolean hasException;
-            @Nullable String message;
+            @Nullable
+            String message;
 
             LoggerCallContext(@Nullable Expression messageArg, int messageArgIndex, boolean hasException, @Nullable String message) {
                 this.messageArg = messageArg;

--- a/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
@@ -25,7 +25,6 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.Comment;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.marker.SearchResult;
 
@@ -103,7 +102,6 @@ public class InvalidExceptionUsageRecipe extends Recipe {
             String actionMessage = "%s specific not %s".formatted(action, simpleType);
             return RecipeMarkerUtil.createTaskMessage(actionMessage, RECIPE_NAME);
         }
-
 
 
         /**

--- a/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
@@ -62,8 +62,9 @@ public class InvalidExceptionUsageRecipe extends Recipe {
     }
 
     @Override public String getDescription() {
-        return "Flags usage of generic exception types (Exception, RuntimeException, Throwable) " +
-            "in catch blocks and throw statements. Code should use specific exception types instead.";
+        return """
+            Flags usage of generic exception types (Exception, RuntimeException, Throwable) \
+            in catch blocks and throw statements. Code should use specific exception types instead.""";
     }
 
     @Override public Set<String> getTags() {
@@ -92,7 +93,7 @@ public class InvalidExceptionUsageRecipe extends Recipe {
          * @return the complete task message with suppression hint
          */
         private String createTaskMessage(String action, String simpleType) {
-            return String.format("TODO: %s specific not %s. Suppress: // cui-rewrite:disable %s",
+            return "TODO: %s specific not %s. Suppress: // cui-rewrite:disable %s".formatted(
                 action, simpleType, RECIPE_NAME);
         }
 
@@ -190,7 +191,8 @@ public class InvalidExceptionUsageRecipe extends Recipe {
             return super.visitClassDeclaration(classDecl, ctx);
         }
 
-        @Override @SuppressWarnings("java:S2637") // SearchResult.found() never returns null for non-null input
+        @Override @SuppressWarnings("java:S2637")
+        // SearchResult.found() never returns null for non-null input
         public J.Try.Catch visitCatch(J.Try.Catch catchBlock, ExecutionContext ctx) {
             J.Try.Catch c = super.visitCatch(catchBlock, ctx);
 
@@ -239,7 +241,8 @@ public class InvalidExceptionUsageRecipe extends Recipe {
             return c;
         }
 
-        @Override @SuppressWarnings("java:S2637") // SearchResult.found() never returns null for non-null input
+        @Override @SuppressWarnings("java:S2637")
+        // SearchResult.found() never returns null for non-null input
         public J.Throw visitThrow(J.Throw thrown, ExecutionContext ctx) {
             J.Throw t = super.visitThrow(thrown, ctx);
 
@@ -268,7 +271,8 @@ public class InvalidExceptionUsageRecipe extends Recipe {
             return t;
         }
 
-        @Override @SuppressWarnings("java:S2637") // SearchResult.found() never returns null for non-null input
+        @Override @SuppressWarnings("java:S2637")
+        // SearchResult.found() never returns null for non-null input
         public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
             J.NewClass nc = super.visitNewClass(newClass, ctx);
 

--- a/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
@@ -57,29 +57,35 @@ public class InvalidExceptionUsageRecipe extends Recipe {
         "java.lang.Throwable"
     );
 
-    @Override public String getDisplayName() {
+    @Override
+    public String getDisplayName() {
         return "Invalid exception usage";
     }
 
-    @Override public String getDescription() {
+    @Override
+    public String getDescription() {
         return """
             Flags usage of generic exception types (Exception, RuntimeException, Throwable) \
             in catch blocks and throw statements. Code should use specific exception types instead.""";
     }
 
-    @Override public Set<String> getTags() {
+    @Override
+    public Set<String> getTags() {
         return Set.of("CUI", "exceptions", "best-practices");
     }
 
-    @Override public Duration getEstimatedEffortPerOccurrence() {
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
         return Duration.ofMinutes(5);
     }
 
-    @Override public TreeVisitor<?, ExecutionContext> getVisitor() {
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new InvalidExceptionUsageVisitor();
     }
 
-    @Override public List<Recipe> getRecipeList() {
+    @Override
+    public List<Recipe> getRecipeList() {
         return List.of();
     }
 
@@ -182,7 +188,8 @@ public class InvalidExceptionUsageRecipe extends Recipe {
         }
 
 
-        @Override public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
             // Check for class-level suppression
             if (RecipeSuppressionUtil.isSuppressed(getCursor(), RECIPE_NAME)) {
                 // Skip the entire class
@@ -191,7 +198,8 @@ public class InvalidExceptionUsageRecipe extends Recipe {
             return super.visitClassDeclaration(classDecl, ctx);
         }
 
-        @Override @SuppressWarnings("java:S2637")
+        @Override
+        @SuppressWarnings("java:S2637")
         // SearchResult.found() never returns null for non-null input
         public J.Try.Catch visitCatch(J.Try.Catch catchBlock, ExecutionContext ctx) {
             J.Try.Catch c = super.visitCatch(catchBlock, ctx);
@@ -241,7 +249,8 @@ public class InvalidExceptionUsageRecipe extends Recipe {
             return c;
         }
 
-        @Override @SuppressWarnings("java:S2637")
+        @Override
+        @SuppressWarnings("java:S2637")
         // SearchResult.found() never returns null for non-null input
         public J.Throw visitThrow(J.Throw thrown, ExecutionContext ctx) {
             J.Throw t = super.visitThrow(thrown, ctx);
@@ -271,7 +280,8 @@ public class InvalidExceptionUsageRecipe extends Recipe {
             return t;
         }
 
-        @Override @SuppressWarnings("java:S2637")
+        @Override
+        @SuppressWarnings("java:S2637")
         // SearchResult.found() never returns null for non-null input
         public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
             J.NewClass nc = super.visitNewClass(newClass, ctx);

--- a/src/main/java/de/cuioss/rewrite/logging/PlaceholderValidationUtil.java
+++ b/src/main/java/de/cuioss/rewrite/logging/PlaceholderValidationUtil.java
@@ -67,7 +67,8 @@ public final class PlaceholderValidationUtil {
      * @param message the message to correct
      * @return the corrected message with all placeholders replaced by %s
      */
-    @Nullable public static String correctPlaceholders(@Nullable String message) {
+    @Nullable
+    public static String correctPlaceholders(@Nullable String message) {
         if (message == null) {
             return null;
         }

--- a/src/main/java/de/cuioss/rewrite/util/BaseSuppressionVisitor.java
+++ b/src/main/java/de/cuioss/rewrite/util/BaseSuppressionVisitor.java
@@ -45,14 +45,16 @@ public abstract class BaseSuppressionVisitor extends JavaIsoVisitor<ExecutionCon
         return RecipeSuppressionUtil.isSuppressed(getCursor(), recipeName);
     }
 
-    @Override public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+    @Override
+    public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
         if (isSuppressed()) {
             return classDecl; // Skip entire class and children - this pattern is always the same
         }
         return super.visitClassDeclaration(classDecl, ctx);
     }
 
-    @Override public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+    @Override
+    public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
         if (isSuppressed()) {
             return method; // Skip entire method and children - this pattern is always the same
         }

--- a/src/main/java/de/cuioss/rewrite/util/RecipeMarkerUtil.java
+++ b/src/main/java/de/cuioss/rewrite/util/RecipeMarkerUtil.java
@@ -32,7 +32,7 @@ public final class RecipeMarkerUtil {
     }
 
     /**
-     * Creates a TODO task message with suppression hint.
+     * Creates a TO-DO task message with suppression hint.
      *
      * @param action the action description (e.g., "Use CuiLogger", "Fix parameter count")
      * @param recipeName the name of the recipe for suppression

--- a/src/main/java/de/cuioss/rewrite/util/RecipeMarkerUtil.java
+++ b/src/main/java/de/cuioss/rewrite/util/RecipeMarkerUtil.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.rewrite.util;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.SearchResult;
+
+/**
+ * Utility class for managing OpenRewrite recipe markers and task comments.
+ * Provides methods to create consistent task messages and check for existing markers.
+ */
+public final class RecipeMarkerUtil {
+
+    private RecipeMarkerUtil() {
+        // Utility class
+    }
+
+    /**
+     * Creates a TODO task message with suppression hint.
+     *
+     * @param action the action description (e.g., "Use CuiLogger", "Fix parameter count")
+     * @param recipeName the name of the recipe for suppression
+     * @return formatted task message with suppression hint
+     */
+    public static String createTaskMessage(String action, String recipeName) {
+        return "TODO: %s. Suppress: // cui-rewrite:disable %s".formatted(action, recipeName);
+    }
+
+    /**
+     * Checks if a J element already has a SearchResult marker.
+     *
+     * @param element the Java element to check
+     * @return true if the element has a SearchResult marker
+     */
+    public static boolean hasSearchResultMarker(J element) {
+        return element.getMarkers().findFirst(SearchResult.class).isPresent();
+    }
+
+    /**
+     * Checks if a Space contains a multiline comment with the given message.
+     * This prevents duplicate markers when recipes run multiple times.
+     *
+     * @param space the Space to check for comments
+     * @param taskMessage the task message to search for
+     * @param cursor the current cursor for printing comments
+     * @return true if a matching comment exists
+     */
+    public static boolean containsTaskInSpace(Space space, String taskMessage, Cursor cursor) {
+        return space.getComments().stream()
+            .filter(Comment::isMultiline)
+            .map(comment -> comment.printComment(cursor))
+            .anyMatch(text -> text.contains(taskMessage));
+    }
+
+    /**
+     * Checks if a task comment already exists for the given element.
+     * This prevents duplicate markers when recipes run multiple times.
+     *
+     * @param element the element to check
+     * @param taskMessage the task message to search for
+     * @param cursor the current cursor for printing comments
+     * @return true if a matching task comment exists
+     */
+    public static boolean hasTaskComment(J element, String taskMessage, Cursor cursor) {
+        return switch (element) {
+            case J.Try.Catch catchBlock -> hasTaskCommentInCatchBlock(catchBlock, taskMessage, cursor);
+            case J.Throw throwStmt -> hasTaskCommentInThrowStatement(throwStmt, taskMessage, cursor);
+            case J.NewClass newClass -> containsTaskInSpace(newClass.getPrefix(), taskMessage, cursor);
+            case J.MethodInvocation mi -> containsTaskInSpace(mi.getPrefix(), taskMessage, cursor);
+            default -> containsTaskInSpace(element.getPrefix(), taskMessage, cursor);
+        };
+    }
+
+    private static boolean hasTaskCommentInCatchBlock(J.Try.Catch catchBlock, String taskMessage, Cursor cursor) {
+        if (containsTaskInSpace(catchBlock.getPrefix(), taskMessage, cursor)) {
+            return true;
+        }
+        // Also check the body prefix
+        return containsTaskInSpace(catchBlock.getBody().getPrefix(), taskMessage, cursor);
+    }
+
+    private static boolean hasTaskCommentInThrowStatement(J.Throw throwStmt, String taskMessage, Cursor cursor) {
+        if (containsTaskInSpace(throwStmt.getPrefix(), taskMessage, cursor)) {
+            return true;
+        }
+        // Also check exception prefix if it's a NewClass
+        if (throwStmt.getException() instanceof J.NewClass nc) {
+            return containsTaskInSpace(nc.getPrefix(), taskMessage, cursor);
+        }
+        return false;
+    }
+}

--- a/src/main/java/de/cuioss/rewrite/util/RecipeSuppressionUtil.java
+++ b/src/main/java/de/cuioss/rewrite/util/RecipeSuppressionUtil.java
@@ -37,7 +37,7 @@ import java.util.List;
  */
 public final class RecipeSuppressionUtil {
 
-    private static final CuiLogger LOG = new CuiLogger(RecipeSuppressionUtil.class);
+    private static final CuiLogger LOGGER = new CuiLogger(RecipeSuppressionUtil.class);
     private static final String SUPPRESSION_MARKER = "cui-rewrite:disable";
 
     /**
@@ -234,10 +234,10 @@ public final class RecipeSuppressionUtil {
         String elementName = getElementName(element);
 
         if (recipeName != null) {
-            LOG.debug("Skipping %s '%s' for recipe '%s' due to %s comment",
+            LOGGER.debug("Skipping %s '%s' for recipe '%s' due to %s comment",
                 elementType, elementName, recipeName, SUPPRESSION_MARKER);
         } else {
-            LOG.debug("Skipping %s '%s' due to %s comment",
+            LOGGER.debug("Skipping %s '%s' due to %s comment",
                 elementType, elementName, SUPPRESSION_MARKER);
         }
     }
@@ -337,7 +337,7 @@ public final class RecipeSuppressionUtil {
             if (value instanceof J.ClassDeclaration cd) {
                 // Check if this class has suppression comment
                 if (hasSuppression(cd.getPrefix().getComments(), cursor, recipeName)) {
-                    LOG.debug("Found class-level suppression on class %s for recipe %s",
+                    LOGGER.debug("Found class-level suppression on class %s for recipe %s",
                         cd.getSimpleName(), recipeName);
                     return true;
                 }
@@ -346,7 +346,7 @@ public final class RecipeSuppressionUtil {
                 // Comments between annotations often get attached to the next annotation
                 for (J.Annotation annotation : cd.getLeadingAnnotations()) {
                     if (hasSuppression(annotation.getPrefix().getComments(), cursor, recipeName)) {
-                        LOG.debug("Found class-level suppression on class %s annotation for recipe %s",
+                        LOGGER.debug("Found class-level suppression on class %s annotation for recipe %s",
                             cd.getSimpleName(), recipeName);
                         return true;
                     }
@@ -354,7 +354,7 @@ public final class RecipeSuppressionUtil {
 
                 // Also check the class body prefix for trailing comments
                 if (hasSuppression(cd.getBody().getPrefix().getComments(), cursor, recipeName)) {
-                    LOG.debug("Found class-level suppression on class %s body for recipe %s",
+                    LOGGER.debug("Found class-level suppression on class %s body for recipe %s",
                         cd.getSimpleName(), recipeName);
                     return true;
                 }

--- a/src/main/java/de/cuioss/rewrite/util/RecipeSuppressionUtil.java
+++ b/src/main/java/de/cuioss/rewrite/util/RecipeSuppressionUtil.java
@@ -273,7 +273,8 @@ public final class RecipeSuppressionUtil {
     /**
      * Helper method: checks parents within a boundary.
      */
-    @SafeVarargs private static boolean checkParentsWithinBoundary(Cursor cursor, String recipeName,
+    @SafeVarargs
+    private static boolean checkParentsWithinBoundary(Cursor cursor, String recipeName,
         Class<? extends J> stopAtType, Class<? extends J>... parentTypes) {
         Cursor parentCursor = cursor.getParentTreeCursor();
         while (true) {
@@ -302,7 +303,8 @@ public final class RecipeSuppressionUtil {
     /**
      * Helper method: finds first parent of any of the specified types and checks suppression.
      */
-    @SafeVarargs private static boolean checkFirstParentOfTypes(Cursor cursor, String recipeName, Class<? extends J>... parentTypes) {
+    @SafeVarargs
+    private static boolean checkFirstParentOfTypes(Cursor cursor, String recipeName, Class<? extends J>... parentTypes) {
         Cursor parentCursor = cursor.getParentTreeCursor();
         while (true) {
             Object value = parentCursor.getValue();
@@ -329,7 +331,8 @@ public final class RecipeSuppressionUtil {
      * @return true if a parent class has suppression
      */
     // owolff: Refactoring would introduce complexity - hence suppressing
-    @SuppressWarnings("java:S3776") private static boolean isParentClassSuppressed(Cursor cursor, String recipeName) {
+    @SuppressWarnings("java:S3776")
+    private static boolean isParentClassSuppressed(Cursor cursor, String recipeName) {
         // Walk up the cursor tree looking for class declarations
         Cursor current = cursor;
         while (current != null) {

--- a/src/test/java/de/cuioss/rewrite/format/AnnotationNewlineFormatIssue1Test.java
+++ b/src/test/java/de/cuioss/rewrite/format/AnnotationNewlineFormatIssue1Test.java
@@ -29,7 +29,8 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions
 class AnnotationNewlineFormatIssue1Test implements RewriteTest {
 
-    @Override public void defaults(RecipeSpec spec) {
+    @Override
+    public void defaults(RecipeSpec spec) {
         spec.recipe(new AnnotationNewlineFormat())
             .parser(JavaParser.fromJavaVersion());
     }
@@ -38,7 +39,8 @@ class AnnotationNewlineFormatIssue1Test implements RewriteTest {
      * Test proper indentation for nested class annotations.
      * The formatted annotation should maintain the parent class indentation (4 spaces).
      */
-    @Test void nestedClassShouldPreserveIndentation() {
+    @Test
+    void nestedClassShouldPreserveIndentation() {
         rewriteRun(
             java(
                 """
@@ -68,7 +70,8 @@ class AnnotationNewlineFormatIssue1Test implements RewriteTest {
     /**
      * Test deeply nested class indentation.
      */
-    @Test void deeplyNestedClassShouldPreserveIndentation() {
+    @Test
+    void deeplyNestedClassShouldPreserveIndentation() {
         rewriteRun(
             java(
                 """
@@ -97,7 +100,8 @@ class AnnotationNewlineFormatIssue1Test implements RewriteTest {
     /**
      * Test method annotation indentation in nested class.
      */
-    @Test void methodInNestedClassShouldPreserveIndentation() {
+    @Test
+    void methodInNestedClassShouldPreserveIndentation() {
         rewriteRun(
             java(
                 """

--- a/src/test/java/de/cuioss/rewrite/format/AnnotationNewlineFormatIssue2Test.java
+++ b/src/test/java/de/cuioss/rewrite/format/AnnotationNewlineFormatIssue2Test.java
@@ -25,7 +25,8 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class AnnotationNewlineFormatIssue2Test implements RewriteTest {
 
-    @Override public void defaults(RecipeSpec spec) {
+    @Override
+    public void defaults(RecipeSpec spec) {
         spec.recipe(new AnnotationNewlineFormat())
             .parser(JavaParser.fromJavaVersion());
     }
@@ -39,7 +40,8 @@ class AnnotationNewlineFormatIssue2Test implements RewriteTest {
      * 2. The comment is intentionally placed on the same line as the annotation
      * 3. There's no formatting issue to fix
      */
-    @Test void shouldNotReformatAnnotationWithTrailingInlineComment() {
+    @Test
+    void shouldNotReformatAnnotationWithTrailingInlineComment() {
         rewriteRun(
             java(
                 """
@@ -58,7 +60,8 @@ class AnnotationNewlineFormatIssue2Test implements RewriteTest {
     /**
      * Similar test case: Class-level annotation with trailing comment
      */
-    @Test void shouldNotReformatClassAnnotationWithTrailingInlineComment() {
+    @Test
+    void shouldNotReformatClassAnnotationWithTrailingInlineComment() {
         rewriteRun(
             java(
                 """
@@ -76,7 +79,8 @@ class AnnotationNewlineFormatIssue2Test implements RewriteTest {
     /**
      * Similar test case: Field-level annotation with trailing comment
      */
-    @Test void shouldNotReformatFieldAnnotationWithTrailingInlineComment() {
+    @Test
+    void shouldNotReformatFieldAnnotationWithTrailingInlineComment() {
         rewriteRun(
             java(
                 """

--- a/src/test/java/de/cuioss/rewrite/format/AnnotationNewlineFormatIssue2Test.java
+++ b/src/test/java/de/cuioss/rewrite/format/AnnotationNewlineFormatIssue2Test.java
@@ -25,8 +25,7 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class AnnotationNewlineFormatIssue2Test implements RewriteTest {
 
-    @Override
-    public void defaults(RecipeSpec spec) {
+    @Override public void defaults(RecipeSpec spec) {
         spec.recipe(new AnnotationNewlineFormat())
             .parser(JavaParser.fromJavaVersion());
     }
@@ -40,8 +39,7 @@ class AnnotationNewlineFormatIssue2Test implements RewriteTest {
      * 2. The comment is intentionally placed on the same line as the annotation
      * 3. There's no formatting issue to fix
      */
-    @Test
-    void shouldNotReformatAnnotationWithTrailingInlineComment() {
+    @Test void shouldNotReformatAnnotationWithTrailingInlineComment() {
         rewriteRun(
             java(
                 """
@@ -52,7 +50,7 @@ class AnnotationNewlineFormatIssue2Test implements RewriteTest {
                     }
                 }
                 """
-                // Expected: NO CHANGE - this code should remain exactly as is
+            // Expected: NO CHANGE - this code should remain exactly as is
             )
         );
     }
@@ -60,8 +58,7 @@ class AnnotationNewlineFormatIssue2Test implements RewriteTest {
     /**
      * Similar test case: Class-level annotation with trailing comment
      */
-    @Test
-    void shouldNotReformatClassAnnotationWithTrailingInlineComment() {
+    @Test void shouldNotReformatClassAnnotationWithTrailingInlineComment() {
         rewriteRun(
             java(
                 """
@@ -71,7 +68,7 @@ class AnnotationNewlineFormatIssue2Test implements RewriteTest {
                     }
                 }
                 """
-                // Expected: NO CHANGE
+            // Expected: NO CHANGE
             )
         );
     }
@@ -79,8 +76,7 @@ class AnnotationNewlineFormatIssue2Test implements RewriteTest {
     /**
      * Similar test case: Field-level annotation with trailing comment
      */
-    @Test
-    void shouldNotReformatFieldAnnotationWithTrailingInlineComment() {
+    @Test void shouldNotReformatFieldAnnotationWithTrailingInlineComment() {
         rewriteRun(
             java(
                 """
@@ -89,7 +85,7 @@ class AnnotationNewlineFormatIssue2Test implements RewriteTest {
                     private String legacyLogger;
                 }
                 """
-                // Expected: NO CHANGE
+            // Expected: NO CHANGE
             )
         );
     }

--- a/src/test/java/de/cuioss/rewrite/format/AnnotationNewlineFormatTest.java
+++ b/src/test/java/de/cuioss/rewrite/format/AnnotationNewlineFormatTest.java
@@ -315,7 +315,7 @@ class AnnotationNewlineFormatTest implements RewriteTest {
                     }
                 }
                 """
-                // Expected: NO CHANGE - inline comment is preserved
+            // Expected: NO CHANGE - inline comment is preserved
             )
         );
     }
@@ -334,7 +334,7 @@ class AnnotationNewlineFormatTest implements RewriteTest {
                     }
                 }
                 """
-                // Expected: NO CHANGE - inline comment is preserved
+            // Expected: NO CHANGE - inline comment is preserved
             )
         );
     }
@@ -352,7 +352,7 @@ class AnnotationNewlineFormatTest implements RewriteTest {
                     }
                 }
                 """
-                // Expected: NO CHANGE - inline comment should be preserved
+            // Expected: NO CHANGE - inline comment should be preserved
             )
         );
     }
@@ -370,10 +370,10 @@ class AnnotationNewlineFormatTest implements RewriteTest {
                     }
                 }
                 """
-                // If this test fails with the transformation below, then we've reproduced the bug:
-                // @SuppressWarnings("java:S1612")
-                // // Cannot use method reference due to ambiguous get() methods
-                // void concurrentAccess() {
+            // If this test fails with the transformation below, then we've reproduced the bug:
+            // @SuppressWarnings("java:S1612")
+            // // Cannot use method reference due to ambiguous get() methods
+            // void concurrentAccess() {
             )
         );
     }
@@ -391,7 +391,7 @@ class AnnotationNewlineFormatTest implements RewriteTest {
                     }
                 }
                 """
-                // Expected: NO CHANGE - already properly formatted
+            // Expected: NO CHANGE - already properly formatted
             )
         );
     }
@@ -409,7 +409,7 @@ class AnnotationNewlineFormatTest implements RewriteTest {
                     }
                 }
                 """
-                // Expected: NO CHANGE - inline comment should be preserved
+            // Expected: NO CHANGE - inline comment should be preserved
             )
         );
     }
@@ -426,11 +426,11 @@ class AnnotationNewlineFormatTest implements RewriteTest {
                     }
                 }
                 """
-                // Expected: NO CHANGE
-                // Should NOT transform to:
-                // @SuppressWarnings("java:S1612")
-                // // Cannot use method reference due to ambiguous get() methods
-                // void concurrentAccess() {
+            // Expected: NO CHANGE
+            // Should NOT transform to:
+            // @SuppressWarnings("java:S1612")
+            // // Cannot use method reference due to ambiguous get() methods
+            // void concurrentAccess() {
             )
         );
     }
@@ -449,7 +449,7 @@ class AnnotationNewlineFormatTest implements RewriteTest {
                     }
                 }
                 """
-                // Expected: NO CHANGE - trailing comment is preserved
+            // Expected: NO CHANGE - trailing comment is preserved
             )
         );
     }
@@ -467,7 +467,7 @@ class AnnotationNewlineFormatTest implements RewriteTest {
                     }
                 }
                 """
-                // Expected: NO CHANGE - trailing comment is preserved
+            // Expected: NO CHANGE - trailing comment is preserved
             )
         );
     }
@@ -485,7 +485,7 @@ class AnnotationNewlineFormatTest implements RewriteTest {
                     private final List<String> asList = null;
                 }
                 """
-                // Expected: NO CHANGE - trailing comment is preserved
+            // Expected: NO CHANGE - trailing comment is preserved
             )
         );
     }

--- a/src/test/java/de/cuioss/rewrite/format/AnnotationNewlineFormatTest.java
+++ b/src/test/java/de/cuioss/rewrite/format/AnnotationNewlineFormatTest.java
@@ -26,12 +26,14 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class AnnotationNewlineFormatTest implements RewriteTest {
 
-    @Override public void defaults(RecipeSpec spec) {
+    @Override
+    public void defaults(RecipeSpec spec) {
         spec.recipe(new AnnotationNewlineFormat())
             .parser(JavaParser.fromJavaVersion());
     }
 
-    @Test void formatSingleClassAnnotation() {
+    @Test
+    void formatSingleClassAnnotation() {
         rewriteRun(
             java(
                 """
@@ -49,7 +51,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
         );
     }
 
-    @Test void formatMultipleClassAnnotations() {
+    @Test
+    void formatMultipleClassAnnotations() {
         rewriteRun(
             java(
                 """
@@ -70,7 +73,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
         );
     }
 
-    @Test void preserveExistingNewlines() {
+    @Test
+    void preserveExistingNewlines() {
         rewriteRun(
             java(
                 """
@@ -86,7 +90,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
         );
     }
 
-    @Test void formatInterfaceAnnotations() {
+    @Test
+    void formatInterfaceAnnotations() {
         rewriteRun(
             java(
                 """
@@ -104,7 +109,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
         );
     }
 
-    @Test void formatEnumAnnotations() {
+    @Test
+    void formatEnumAnnotations() {
         rewriteRun(
             java(
                 """
@@ -122,7 +128,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
         );
     }
 
-    @Test void formatPackagePrivateMethodWithAnnotation() {
+    @Test
+    void formatPackagePrivateMethodWithAnnotation() {
         rewriteRun(
             java(
                 """
@@ -144,7 +151,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
         );
     }
 
-    @Test void formatPackagePrivateFieldWithAnnotation() {
+    @Test
+    void formatPackagePrivateFieldWithAnnotation() {
         rewriteRun(
             java(
                 """
@@ -162,7 +170,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
         );
     }
 
-    @Test void formatMultiplePackagePrivateFieldsWithAnnotations() {
+    @Test
+    void formatMultiplePackagePrivateFieldsWithAnnotations() {
         rewriteRun(
             java(
                 """
@@ -184,7 +193,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
         );
     }
 
-    @Test void formatPackagePrivateClassWithAnnotation() {
+    @Test
+    void formatPackagePrivateClassWithAnnotation() {
         // This test expects no change since package-private classes at top level
         // already have the correct formatting
         rewriteRun(
@@ -199,7 +209,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
         );
     }
 
-    @Test void formatMethodWithoutModifiersButWithReturnType() {
+    @Test
+    void formatMethodWithoutModifiersButWithReturnType() {
         rewriteRun(
             java(
                 """
@@ -222,7 +233,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
         );
     }
 
-    @Test void formatFieldWithoutModifiersButWithType() {
+    @Test
+    void formatFieldWithoutModifiersButWithType() {
         rewriteRun(
             java(
                 """
@@ -241,7 +253,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
         );
     }
 
-    @Test void preserveFormattingWhenNoAnnotations() {
+    @Test
+    void preserveFormattingWhenNoAnnotations() {
         rewriteRun(
             java(
                 """
@@ -257,7 +270,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
         );
     }
 
-    @Test void formatNestedClassAnnotations() {
+    @Test
+    void formatNestedClassAnnotations() {
         rewriteRun(
             java(
                 """
@@ -284,7 +298,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
         );
     }
 
-    @Test void formatAnnotationWithArrayValues() {
+    @Test
+    void formatAnnotationWithArrayValues() {
         rewriteRun(
             java(
                 """
@@ -305,7 +320,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
     // FIXED: Trailing comments on annotations are now preserved on the same line
     // This was previously a known limitation, but has been resolved.
     // Single annotations with inline comments are now left untouched.
-    @Test void preserveTrailingCommentsOnSingleAnnotation() {
+    @Test
+    void preserveTrailingCommentsOnSingleAnnotation() {
         rewriteRun(
             java(
                 """
@@ -324,7 +340,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
     // FIXED: Trailing inline comments are now preserved on the same line
     // This was previously a known limitation, but has been resolved.
     // Single annotations with inline comments are now left untouched.
-    @Test void preserveTrailingCommentOnSingleAnnotation() {
+    @Test
+    void preserveTrailingCommentOnSingleAnnotation() {
         rewriteRun(
             java(
                 """
@@ -342,7 +359,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
 
     // Reproducing Issue: Trailing comments are being moved to separate line
     // when method has no modifiers (package-private)
-    @Test void preserveTrailingCommentOnAnnotationWithPackagePrivateMethod() {
+    @Test
+    void preserveTrailingCommentOnAnnotationWithPackagePrivateMethod() {
         rewriteRun(
             java(
                 """
@@ -360,7 +378,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
 
     // Test if the recipe is incorrectly transforming trailing comments
     // This test expects the WRONG behavior (if it happens)
-    @Test void shouldNotMoveTrailingCommentToNewLine() {
+    @Test
+    void shouldNotMoveTrailingCommentToNewLine() {
         rewriteRun(
             java(
                 """
@@ -381,7 +400,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
 
     // Test with method that already has the annotation on a separate line
     // to ensure the recipe skips it
-    @Test void skipWhenAnnotationAlreadyOnSeparateLine() {
+    @Test
+    void skipWhenAnnotationAlreadyOnSeparateLine() {
         rewriteRun(
             java(
                 """
@@ -399,7 +419,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
 
     // Test with annotation already on separate line BUT with trailing comment
     // The comment should stay on the annotation's line
-    @Test void annotationOnSeparateLineWithTrailingComment() {
+    @Test
+    void annotationOnSeparateLineWithTrailingComment() {
         rewriteRun(
             java(
                 """
@@ -416,7 +437,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
     }
 
     // Test the EXACT scenario from the user's example with proper indentation
-    @Test void exactUserScenarioWithTrailingComment() {
+    @Test
+    void exactUserScenarioWithTrailingComment() {
         rewriteRun(
             java(
                 """
@@ -438,7 +460,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
 
     // FIXED: Multiple annotations with trailing comment on last annotation
     // The recipe now correctly preserves trailing comments
-    @Test void multipleAnnotationsWithTrailingCommentOnLast_ShouldPreserveComment() {
+    @Test
+    void multipleAnnotationsWithTrailingCommentOnLast_ShouldPreserveComment() {
         rewriteRun(
             java(
                 """
@@ -456,7 +479,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
     }
 
     // FIXED: @Override with trailing comment
-    @Test void overrideAnnotationWithTrailingComment_ShouldPreserveComment() {
+    @Test
+    void overrideAnnotationWithTrailingComment_ShouldPreserveComment() {
         rewriteRun(
             java(
                 """
@@ -474,7 +498,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
     }
 
     // FIXED: Field with multiple annotations and trailing comment on last
-    @Test void fieldWithMultipleAnnotationsAndTrailingComment_ShouldPreserveComment() {
+    @Test
+    void fieldWithMultipleAnnotationsAndTrailingComment_ShouldPreserveComment() {
         rewriteRun(
             java(
                 """
@@ -492,11 +517,39 @@ class AnnotationNewlineFormatTest implements RewriteTest {
     }
 
     /**
+     * Test that single method annotation is separated from modifiers.
+     * Issue: @SafeVarargs private static boolean -> should be @SafeVarargs\nprivate static boolean
+     */
+    @Test
+    void shouldSeparateSingleMethodAnnotationFromModifiers() {
+        rewriteRun(
+            java(
+                """
+                class TestClass {
+                    @SafeVarargs private static boolean check(Class<?>... types) {
+                        return true;
+                    }
+                }
+                """,
+                """
+                class TestClass {
+                    @SafeVarargs
+                    private static boolean check(Class<?>... types) {
+                        return true;
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    /**
      * Test that method annotations maintain proper indentation when split.
      * Both annotations should have 4-space indentation to match the method's context.
      * This is critical because AutoFormat will recombine annotations with inconsistent indentation.
      */
-    @Test void shouldPreserveIndentationForMethodAnnotations() {
+    @Test
+    void shouldPreserveIndentationForMethodAnnotations() {
         rewriteRun(
             java(
                 """
@@ -521,7 +574,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
      * Reproduces the AutoFormat issue: After AnnotationNewlineFormat splits class-level annotations,
      * AutoFormat should NOT recombine them. This test verifies the formatting persists through AutoFormat.
      */
-    @Test void classAnnotationsShouldPersistThroughAutoFormat() {
+    @Test
+    void classAnnotationsShouldPersistThroughAutoFormat() {
         rewriteRun(
             spec -> spec.recipe(new AnnotationNewlineFormat())
                 .recipe(new AutoFormat())

--- a/src/test/java/de/cuioss/rewrite/format/AnnotationNewlineFormatTest.java
+++ b/src/test/java/de/cuioss/rewrite/format/AnnotationNewlineFormatTest.java
@@ -317,11 +317,8 @@ class AnnotationNewlineFormatTest implements RewriteTest {
         );
     }
 
-    // FIXED: Trailing comments on annotations are now preserved on the same line
-    // This was previously a known limitation, but has been resolved.
-    // Single annotations with inline comments are now left untouched.
     @Test
-    void preserveTrailingCommentsOnSingleAnnotation() {
+    void preserveTrailingCommentOnSingleAnnotation() {
         rewriteRun(
             java(
                 """
@@ -332,35 +329,12 @@ class AnnotationNewlineFormatTest implements RewriteTest {
                     }
                 }
                 """
-            // Expected: NO CHANGE - inline comment is preserved
             )
         );
     }
 
-    // FIXED: Trailing inline comments are now preserved on the same line
-    // This was previously a known limitation, but has been resolved.
-    // Single annotations with inline comments are now left untouched.
     @Test
-    void preserveTrailingCommentOnSingleAnnotation() {
-        rewriteRun(
-            java(
-                """
-                public class AccessTokenCache {
-                    @SuppressWarnings("java:S3776") // owolff: 16 instead of 15 is acceptable here due to complexity of cache logic
-                    public String computeIfAbsent(String key) {
-                        return null;
-                    }
-                }
-                """
-            // Expected: NO CHANGE - inline comment is preserved
-            )
-        );
-    }
-
-    // Reproducing Issue: Trailing comments are being moved to separate line
-    // when method has no modifiers (package-private)
-    @Test
-    void preserveTrailingCommentOnAnnotationWithPackagePrivateMethod() {
+    void preserveTrailingCommentOnPackagePrivateMethod() {
         rewriteRun(
             java(
                 """
@@ -371,75 +345,12 @@ class AnnotationNewlineFormatTest implements RewriteTest {
                     }
                 }
                 """
-            // Expected: NO CHANGE - inline comment should be preserved
             )
         );
     }
 
-    // Test with method that already has the annotation on a separate line
-    // to ensure the recipe skips it
     @Test
-    void skipWhenAnnotationAlreadyOnSeparateLine() {
-        rewriteRun(
-            java(
-                """
-                public class TestClass {
-                    @SuppressWarnings("java:S1612")
-                    void concurrentAccess() {
-                        // method body
-                    }
-                }
-                """
-            // Expected: NO CHANGE - already properly formatted
-            )
-        );
-    }
-
-    // Test with annotation already on separate line BUT with trailing comment
-    // The comment should stay on the annotation's line
-    @Test
-    void annotationOnSeparateLineWithTrailingComment() {
-        rewriteRun(
-            java(
-                """
-                public class TestClass {
-                    @SuppressWarnings("java:S1612") // Cannot use method reference due to ambiguous get() methods
-                    void concurrentAccess() {
-                        // method body
-                    }
-                }
-                """
-            // Expected: NO CHANGE - inline comment should be preserved
-            )
-        );
-    }
-
-    // Test the EXACT scenario from the user's example with proper indentation
-    @Test
-    void exactUserScenarioWithTrailingComment() {
-        rewriteRun(
-            java(
-                """
-                public class ConcurrentAccessTest {
-                    @SuppressWarnings("java:S1612") // Cannot use method reference due to ambiguous get() methods
-                    void concurrentAccess() {
-                        // Test concurrent access patterns
-                    }
-                }
-                """
-            // Expected: NO CHANGE
-            // Should NOT transform to:
-            // @SuppressWarnings("java:S1612")
-            // // Cannot use method reference due to ambiguous get() methods
-            // void concurrentAccess() {
-            )
-        );
-    }
-
-    // FIXED: Multiple annotations with trailing comment on last annotation
-    // The recipe now correctly preserves trailing comments
-    @Test
-    void multipleAnnotationsWithTrailingCommentOnLast_ShouldPreserveComment() {
+    void preserveTrailingCommentOnMultipleAnnotations() {
         rewriteRun(
             java(
                 """
@@ -451,14 +362,12 @@ class AnnotationNewlineFormatTest implements RewriteTest {
                     }
                 }
                 """
-            // Expected: NO CHANGE - trailing comment is preserved
             )
         );
     }
 
-    // FIXED: @Override with trailing comment
     @Test
-    void overrideAnnotationWithTrailingComment_ShouldPreserveComment() {
+    void preserveTrailingCommentWithOverrideAnnotation() {
         rewriteRun(
             java(
                 """
@@ -470,14 +379,12 @@ class AnnotationNewlineFormatTest implements RewriteTest {
                     }
                 }
                 """
-            // Expected: NO CHANGE - trailing comment is preserved
             )
         );
     }
 
-    // FIXED: Field with multiple annotations and trailing comment on last
     @Test
-    void fieldWithMultipleAnnotationsAndTrailingComment_ShouldPreserveComment() {
+    void preserveTrailingCommentOnFieldAnnotations() {
         rewriteRun(
             java(
                 """
@@ -489,7 +396,6 @@ class AnnotationNewlineFormatTest implements RewriteTest {
                     private final List<String> asList = null;
                 }
                 """
-            // Expected: NO CHANGE - trailing comment is preserved
             )
         );
     }

--- a/src/test/java/de/cuioss/rewrite/format/AnnotationNewlineFormatTest.java
+++ b/src/test/java/de/cuioss/rewrite/format/AnnotationNewlineFormatTest.java
@@ -376,28 +376,6 @@ class AnnotationNewlineFormatTest implements RewriteTest {
         );
     }
 
-    // Test if the recipe is incorrectly transforming trailing comments
-    // This test expects the WRONG behavior (if it happens)
-    @Test
-    void shouldNotMoveTrailingCommentToNewLine() {
-        rewriteRun(
-            java(
-                """
-                public class TestClass {
-                    @SuppressWarnings("java:S1612") // Cannot use method reference due to ambiguous get() methods
-                    void concurrentAccess() {
-                        // method body
-                    }
-                }
-                """
-            // If this test fails with the transformation below, then we've reproduced the bug:
-            // @SuppressWarnings("java:S1612")
-            // // Cannot use method reference due to ambiguous get() methods
-            // void concurrentAccess() {
-            )
-        );
-    }
-
     // Test with method that already has the annotation on a separate line
     // to ensure the recipe skips it
     @Test

--- a/src/test/java/de/cuioss/rewrite/format/AnnotationSuppressionLoggingTest.java
+++ b/src/test/java/de/cuioss/rewrite/format/AnnotationSuppressionLoggingTest.java
@@ -34,12 +34,14 @@ import static org.openrewrite.java.Assertions.java;
 @EnableTestLogger(rootLevel = TestLogLevel.DEBUG)
 class AnnotationSuppressionLoggingTest implements RewriteTest {
 
-    @Override public void defaults(RecipeSpec spec) {
+    @Override
+    public void defaults(RecipeSpec spec) {
         spec.recipe(new AnnotationNewlineFormat())
             .parser(JavaParser.fromJavaVersion());
     }
 
-    @Test void shouldLogWhenClassSuppressionIsTriggered() {
+    @Test
+    void shouldLogWhenClassSuppressionIsTriggered() {
         // when
         rewriteRun(
             java(
@@ -59,7 +61,8 @@ class AnnotationSuppressionLoggingTest implements RewriteTest {
         );
     }
 
-    @Test void shouldLogWhenMethodSuppressionIsTriggered() {
+    @Test
+    void shouldLogWhenMethodSuppressionIsTriggered() {
         // when
         rewriteRun(
             java(
@@ -81,7 +84,8 @@ class AnnotationSuppressionLoggingTest implements RewriteTest {
         );
     }
 
-    @Test void shouldLogWhenFieldSuppressionIsTriggered() {
+    @Test
+    void shouldLogWhenFieldSuppressionIsTriggered() {
         // when
         rewriteRun(
             java(
@@ -101,7 +105,8 @@ class AnnotationSuppressionLoggingTest implements RewriteTest {
         );
     }
 
-    @Test void shouldNotLogWhenNoSuppressionPresent() {
+    @Test
+    void shouldNotLogWhenNoSuppressionPresent() {
         // when - format without suppression comment
         rewriteRun(
             java(
@@ -128,7 +133,8 @@ class AnnotationSuppressionLoggingTest implements RewriteTest {
         );
     }
 
-    @Test void shouldNotLogWarningsOrErrors() {
+    @Test
+    void shouldNotLogWarningsOrErrors() {
         // when - execute any recipe operation
         rewriteRun(
             java(

--- a/src/test/java/de/cuioss/rewrite/format/AnnotationSuppressionTest.java
+++ b/src/test/java/de/cuioss/rewrite/format/AnnotationSuppressionTest.java
@@ -25,12 +25,14 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class AnnotationSuppressionTest implements RewriteTest {
 
-    @Override public void defaults(RecipeSpec spec) {
+    @Override
+    public void defaults(RecipeSpec spec) {
         spec.recipe(new AnnotationNewlineFormat())
             .parser(JavaParser.fromJavaVersion());
     }
 
-    @Test void suppressSingleLineForClass() {
+    @Test
+    void suppressSingleLineForClass() {
         rewriteRun(
             java(
                 """
@@ -43,7 +45,8 @@ class AnnotationSuppressionTest implements RewriteTest {
         );
     }
 
-    @Test void suppressSingleLineForMethod() {
+    @Test
+    void suppressSingleLineForMethod() {
         rewriteRun(
             java(
                 """
@@ -58,7 +61,8 @@ class AnnotationSuppressionTest implements RewriteTest {
         );
     }
 
-    @Test void suppressSingleLineForField() {
+    @Test
+    void suppressSingleLineForField() {
         rewriteRun(
             java(
                 """
@@ -71,7 +75,8 @@ class AnnotationSuppressionTest implements RewriteTest {
         );
     }
 
-    @Test void suppressGlobalAll() {
+    @Test
+    void suppressGlobalAll() {
         rewriteRun(
             java(
                 """
@@ -86,7 +91,8 @@ class AnnotationSuppressionTest implements RewriteTest {
         );
     }
 
-    @Test void suppressSpecificRecipeBySimpleName() {
+    @Test
+    void suppressSpecificRecipeBySimpleName() {
         rewriteRun(
             java(
                 """
@@ -100,7 +106,8 @@ class AnnotationSuppressionTest implements RewriteTest {
         );
     }
 
-    @Test void suppressSpecificRecipeByFullName() {
+    @Test
+    void suppressSpecificRecipeByFullName() {
         rewriteRun(
             java(
                 """
@@ -114,7 +121,8 @@ class AnnotationSuppressionTest implements RewriteTest {
     }
 
 
-    @Test void suppressNextLineWithoutRecipeName() {
+    @Test
+    void suppressNextLineWithoutRecipeName() {
         rewriteRun(
             java(
                 """
@@ -127,7 +135,8 @@ class AnnotationSuppressionTest implements RewriteTest {
         );
     }
 
-    @Test void suppressWithTrailingComment() {
+    @Test
+    void suppressWithTrailingComment() {
         // Note: Trailing comments on the same line are not fully supported 
         // due to OpenRewrite AST limitations. The comment may be attached 
         // to the body or other parts of the AST, making detection unreliable.
@@ -150,7 +159,8 @@ class AnnotationSuppressionTest implements RewriteTest {
         );
     }
 
-    @Test void suppressWithWrongRecipeName() {
+    @Test
+    void suppressWithWrongRecipeName() {
         rewriteRun(
             java(
                 """

--- a/src/test/java/de/cuioss/rewrite/format/LombokAnnotationFormatTest.java
+++ b/src/test/java/de/cuioss/rewrite/format/LombokAnnotationFormatTest.java
@@ -27,14 +27,17 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class LombokAnnotationFormatTest implements RewriteTest {
 
-    @Override public void defaults(RecipeSpec spec) {
+    @Override
+    public void defaults(RecipeSpec spec) {
         spec.recipe(new AnnotationNewlineFormat())
             .parser(JavaParser.fromJavaVersion()
                 .logCompilationWarningsAndErrors(true))
             .typeValidationOptions(TypeValidation.none());
     }
 
-    @DocumentExample @Test void formatUtilityClassAnnotation() {
+    @DocumentExample
+    @Test
+    void formatUtilityClassAnnotation() {
         rewriteRun(
             java(
                 """
@@ -56,7 +59,8 @@ class LombokAnnotationFormatTest implements RewriteTest {
         );
     }
 
-    @Test void formatDataAnnotation() {
+    @Test
+    void formatDataAnnotation() {
         rewriteRun(
             java(
                 """
@@ -80,7 +84,8 @@ class LombokAnnotationFormatTest implements RewriteTest {
         );
     }
 
-    @Test void formatMultipleLombokAnnotations() {
+    @Test
+    void formatMultipleLombokAnnotations() {
         rewriteRun(
             java(
                 """
@@ -113,7 +118,8 @@ class LombokAnnotationFormatTest implements RewriteTest {
         );
     }
 
-    @Test void formatSlf4jAnnotation() {
+    @Test
+    void formatSlf4jAnnotation() {
         rewriteRun(
             java(
                 """
@@ -139,7 +145,8 @@ class LombokAnnotationFormatTest implements RewriteTest {
         );
     }
 
-    @Test void preserveAlreadyFormattedLombokAnnotations() {
+    @Test
+    void preserveAlreadyFormattedLombokAnnotations() {
         rewriteRun(
             java(
                 """
@@ -157,7 +164,8 @@ class LombokAnnotationFormatTest implements RewriteTest {
         );
     }
 
-    @Test void formatMixedLombokAndJavaAnnotations() {
+    @Test
+    void formatMixedLombokAndJavaAnnotations() {
         rewriteRun(
             java(
                 """

--- a/src/test/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipeReproduceTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipeReproduceTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
+// cui-rewrite:disable CuiLogRecordPatternRecipe
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class CuiLogRecordPatternRecipeReproduceTest implements RewriteTest {
 

--- a/src/test/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipeReproduceTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipeReproduceTest.java
@@ -25,11 +25,13 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class CuiLogRecordPatternRecipeReproduceTest implements RewriteTest {
 
-    @Override public void defaults(RecipeSpec spec) {
+    @Override
+    public void defaults(RecipeSpec spec) {
         spec.recipe(new CuiLogRecordPatternRecipe());
     }
 
-    @Test void shouldNotFailOnGetNameMethod() {
+    @Test
+    void shouldNotFailOnGetNameMethod() {
         rewriteRun(
             java(
                 """
@@ -53,7 +55,8 @@ class CuiLogRecordPatternRecipeReproduceTest implements RewriteTest {
         );
     }
 
-    @Test void shouldNotFailOnNonLoggerMethods() {
+    @Test
+    void shouldNotFailOnNonLoggerMethods() {
         rewriteRun(
             java(
                 """

--- a/src/test/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipeTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipeTest.java
@@ -29,7 +29,8 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class CuiLogRecordPatternRecipeTest implements RewriteTest {
 
-    @Override public void defaults(RecipeSpec spec) {
+    @Override
+    public void defaults(RecipeSpec spec) {
         spec.recipe(new CuiLogRecordPatternRecipe())
             .parser(JavaParser.fromJavaVersion()
                 .dependsOn(
@@ -86,7 +87,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
                 ));
     }
 
-    @Test void detectMissingLogRecordForInfo() {
+    @Test
+    void detectMissingLogRecordForInfo() {
         rewriteRun(
             java(
                 """
@@ -117,7 +119,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectMissingLogRecordForError() {
+    @Test
+    void detectMissingLogRecordForError() {
         rewriteRun(
             java(
                 """
@@ -146,7 +149,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectMissingLogRecordForWarn() {
+    @Test
+    void detectMissingLogRecordForWarn() {
         rewriteRun(
             java(
                 """
@@ -175,7 +179,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectLogRecordUsageInDebug() {
+    @Test
+    void detectLogRecordUsageInDebug() {
         rewriteRun(
             java(
                 """
@@ -214,7 +219,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectLogRecordUsageInTrace() {
+    @Test
+    void detectLogRecordUsageInTrace() {
         rewriteRun(
             java(
                 """
@@ -253,7 +259,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void acceptCorrectLogRecordUsageForInfo() {
+    @Test
+    void acceptCorrectLogRecordUsageForInfo() {
         rewriteRun(
             java(
                 """
@@ -280,7 +287,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectZeroParamFormatCallForError() {
+    @Test
+    void detectZeroParamFormatCallForError() {
         rewriteRun(
             java(
                 """
@@ -325,7 +333,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void acceptCorrectDebugWithoutLogRecord() {
+    @Test
+    void acceptCorrectDebugWithoutLogRecord() {
         rewriteRun(
             java(
                 """
@@ -344,7 +353,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void acceptCorrectTraceWithoutLogRecord() {
+    @Test
+    void acceptCorrectTraceWithoutLogRecord() {
         rewriteRun(
             java(
                 """
@@ -362,7 +372,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void suppressionWorks() {
+    @Test
+    void suppressionWorks() {
         rewriteRun(
             java(
                 """
@@ -381,7 +392,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectIncorrectPlaceholderInLogRecordTemplate() {
+    @Test
+    void detectIncorrectPlaceholderInLogRecordTemplate() {
         rewriteRun(
             java(
                 """
@@ -416,7 +428,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void acceptCorrectPlaceholderInLogRecordTemplate() {
+    @Test
+    void acceptCorrectPlaceholderInLogRecordTemplate() {
         rewriteRun(
             java(
                 """
@@ -437,7 +450,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void convertZeroParamFormatToMethodReference() {
+    @Test
+    void convertZeroParamFormatToMethodReference() {
         rewriteRun(
             java(
                 """
@@ -476,7 +490,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void convertZeroParamFormatWithExceptionToMethodReference() {
+    @Test
+    void convertZeroParamFormatWithExceptionToMethodReference() {
         rewriteRun(
             java(
                 """
@@ -521,7 +536,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void doNotConvertFormatWithParameters() {
+    @Test
+    void doNotConvertFormatWithParameters() {
         rewriteRun(
             java(
                 """
@@ -548,7 +564,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void acceptExistingMethodReference() {
+    @Test
+    void acceptExistingMethodReference() {
         rewriteRun(
             java(
                 """
@@ -571,7 +588,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void shouldWorkWithSuppressionComment() {
+    @Test
+    void shouldWorkWithSuppressionComment() {
         rewriteRun(
             java(
                 """
@@ -590,7 +608,8 @@ class CuiLogRecordPatternRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void shouldSkipTestSources() {
+    @Test
+    void shouldSkipTestSources() {
         rewriteRun(
             java(
                 """

--- a/src/test/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipeTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipeTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import static org.openrewrite.java.Assertions.java;
 
+// cui-rewrite:disable CuiLogRecordPatternRecipe
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class CuiLogRecordPatternRecipeTest implements RewriteTest {
 

--- a/src/test/java/de/cuioss/rewrite/logging/CuiLoggerAutoFixTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/CuiLoggerAutoFixTest.java
@@ -26,7 +26,8 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class CuiLoggerAutoFixTest implements RewriteTest {
 
-    @Override public void defaults(RecipeSpec spec) {
+    @Override
+    public void defaults(RecipeSpec spec) {
         spec.recipe(new CuiLoggerStandardsRecipe())
             .typeValidationOptions(TypeValidation.none())
             .parser(JavaParser.fromJavaVersion()
@@ -50,7 +51,8 @@ class CuiLoggerAutoFixTest implements RewriteTest {
                 ));
     }
 
-    @Test void fixesPublicModifierToPrivateStaticFinal() {
+    @Test
+    void fixesPublicModifierToPrivateStaticFinal() {
         rewriteRun(
             java(
                 """
@@ -71,7 +73,8 @@ class CuiLoggerAutoFixTest implements RewriteTest {
         );
     }
 
-    @Test void fixesProtectedModifierToPrivateStaticFinal() {
+    @Test
+    void fixesProtectedModifierToPrivateStaticFinal() {
         rewriteRun(
             java(
                 """
@@ -92,7 +95,8 @@ class CuiLoggerAutoFixTest implements RewriteTest {
         );
     }
 
-    @Test void replacesSLF4JPlaceholders() {
+    @Test
+    void replacesSLF4JPlaceholders() {
         rewriteRun(
             java(
                 """
@@ -123,7 +127,8 @@ class CuiLoggerAutoFixTest implements RewriteTest {
         );
     }
 
-    @Test void replacesPrintfStylePlaceholders() {
+    @Test
+    void replacesPrintfStylePlaceholders() {
         rewriteRun(
             java(
                 """
@@ -154,7 +159,8 @@ class CuiLoggerAutoFixTest implements RewriteTest {
         );
     }
 
-    @Test void movesExceptionToFirstPosition() {
+    @Test
+    void movesExceptionToFirstPosition() {
         rewriteRun(
             java(
                 """
@@ -185,7 +191,8 @@ class CuiLoggerAutoFixTest implements RewriteTest {
         );
     }
 
-    @Test void combinedFixes() {
+    @Test
+    void combinedFixes() {
         rewriteRun(
             java(
                 """
@@ -214,7 +221,8 @@ class CuiLoggerAutoFixTest implements RewriteTest {
         );
     }
 
-    @Test void doesNotChangeCorrectCode() {
+    @Test
+    void doesNotChangeCorrectCode() {
         rewriteRun(
             java(
                 """

--- a/src/test/java/de/cuioss/rewrite/logging/CuiLoggerRenameSimpleTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/CuiLoggerRenameSimpleTest.java
@@ -25,12 +25,14 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class CuiLoggerRenameSimpleTest implements RewriteTest {
 
-    @Override public void defaults(RecipeSpec spec) {
+    @Override
+    public void defaults(RecipeSpec spec) {
         spec.recipe(new CuiLoggerStandardsRecipe())
             .typeValidationOptions(TypeValidation.none());
     }
 
-    @Test void renamesLoggerToUppercase() {
+    @Test
+    void renamesLoggerToUppercase() {
         rewriteRun(
             java(
                 """

--- a/src/test/java/de/cuioss/rewrite/logging/CuiLoggerRenameTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/CuiLoggerRenameTest.java
@@ -25,12 +25,14 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class CuiLoggerRenameTest implements RewriteTest {
 
-    @Override public void defaults(RecipeSpec spec) {
+    @Override
+    public void defaults(RecipeSpec spec) {
         spec.recipe(new CuiLoggerStandardsRecipe())
             .typeValidationOptions(TypeValidation.none());
     }
 
-    @Test void renamesLoggerToUppercase() {
+    @Test
+    void renamesLoggerToUppercase() {
         rewriteRun(
             java(
                 """
@@ -51,7 +53,8 @@ class CuiLoggerRenameTest implements RewriteTest {
         );
     }
 
-    @Test void doesNotRenameCorrectLoggerName() {
+    @Test
+    void doesNotRenameCorrectLoggerName() {
         rewriteRun(
             java(
                 """

--- a/src/test/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipeTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipeTest.java
@@ -27,7 +27,8 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class CuiLoggerStandardsRecipeTest implements RewriteTest {
 
-    @Override public void defaults(RecipeSpec spec) {
+    @Override
+    public void defaults(RecipeSpec spec) {
         spec.recipe(new CuiLoggerStandardsRecipe())
             .typeValidationOptions(TypeValidation.none())
             .parser(JavaParser.fromJavaVersion()
@@ -60,7 +61,8 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
                 ));
     }
 
-    @Test void detectIncorrectLoggerName() {
+    @Test
+    void detectIncorrectLoggerName() {
         rewriteRun(
             java(
                 """
@@ -81,7 +83,8 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectIncorrectLoggerModifiers() {
+    @Test
+    void detectIncorrectLoggerModifiers() {
         rewriteRun(
             java(
                 """
@@ -102,7 +105,8 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectIncorrectPlaceholderPatterns() {
+    @Test
+    void detectIncorrectPlaceholderPatterns() {
         rewriteRun(
             java(
                 """
@@ -135,7 +139,8 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectParameterCountMismatch() {
+    @Test
+    void detectParameterCountMismatch() {
         rewriteRun(
             java(
                 """
@@ -166,7 +171,8 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectWrongExceptionPosition() {
+    @Test
+    void detectWrongExceptionPosition() {
         rewriteRun(
             java(
                 """
@@ -195,7 +201,8 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectSystemOutUsage() {
+    @Test
+    void detectSystemOutUsage() {
         rewriteRun(
             java(
                 """
@@ -218,7 +225,8 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void suppressionWorks() {
+    @Test
+    void suppressionWorks() {
         rewriteRun(
             java(
                 """
@@ -238,7 +246,8 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void correctLoggerUsageNotFlagged() {
+    @Test
+    void correctLoggerUsageNotFlagged() {
         rewriteRun(
             java(
                 """
@@ -258,7 +267,8 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void shouldHandleLoggerWithPublicModifier() {
+    @Test
+    void shouldHandleLoggerWithPublicModifier() {
         rewriteRun(
             java(
                 """
@@ -279,7 +289,8 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void shouldHandleLoggerWithProtectedModifier() {
+    @Test
+    void shouldHandleLoggerWithProtectedModifier() {
         rewriteRun(
             java(
                 """
@@ -300,7 +311,8 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void shouldHandleLoggerWithoutFinalModifier() {
+    @Test
+    void shouldHandleLoggerWithoutFinalModifier() {
         rewriteRun(
             java(
                 """
@@ -321,7 +333,8 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void shouldHandleLoggerWithoutStaticModifier() {
+    @Test
+    void shouldHandleLoggerWithoutStaticModifier() {
         rewriteRun(
             java(
                 """
@@ -342,7 +355,8 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void shouldHandleExceptionFirstWithPlaceholders() {
+    @Test
+    void shouldHandleExceptionFirstWithPlaceholders() {
         rewriteRun(
             java(
                 """
@@ -363,7 +377,8 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void shouldDetectParameterMismatchWithExceptionFirst() {
+    @Test
+    void shouldDetectParameterMismatchWithExceptionFirst() {
         rewriteRun(
             java(
                 """
@@ -396,7 +411,8 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void shouldNotModifyLocalVariableLoggers() {
+    @Test
+    void shouldNotModifyLocalVariableLoggers() {
         rewriteRun(
             java(
                 """

--- a/src/test/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipeTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipeTest.java
@@ -157,7 +157,7 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
 
                     void method() {
                         String value1 = "test";
-                        /*~~(2 placeholders, 1 params)~~>*/LOGGER.info("Message with %s and %s", value1);
+                        /*~~(TODO: 2 placeholders, 1 params. Suppress: // cui-rewrite:disable CuiLoggerStandardsRecipe)~~>*/LOGGER.info("Message with %s and %s", value1);
                     }
                 }
                 """
@@ -387,7 +387,7 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
                     void method(Exception e) {
                         String value = "test";
                         // Exception first, then message with 2 placeholders but only 1 param
-                        /*~~(2 placeholders, 1 params)~~>*/LOGGER.error(e, "Error with %s and %s", value);
+                        /*~~(TODO: 2 placeholders, 1 params. Suppress: // cui-rewrite:disable CuiLoggerStandardsRecipe)~~>*/LOGGER.error(e, "Error with %s and %s", value);
                     }
                 }
                 """

--- a/src/test/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipeTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipeTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 
+// cui-rewrite:disable CuiLoggerStandardsRecipe
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class CuiLoggerStandardsRecipeTest implements RewriteTest {
 

--- a/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeIssue5Test.java
+++ b/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeIssue5Test.java
@@ -30,7 +30,8 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions
 class InvalidExceptionUsageRecipeIssue5Test implements RewriteTest {
 
-    @Override public void defaults(RecipeSpec spec) {
+    @Override
+    public void defaults(RecipeSpec spec) {
         spec.recipe(new InvalidExceptionUsageRecipe())
             .parser(JavaParser.fromJavaVersion());
     }
@@ -39,7 +40,8 @@ class InvalidExceptionUsageRecipeIssue5Test implements RewriteTest {
      * Test scenario: Code already has the TODO marker comment in source.
      * The recipe should recognize it and NOT add another marker.
      */
-    @Test void shouldNotAddDuplicateWhenCommentAlreadyExists() {
+    @Test
+    void shouldNotAddDuplicateWhenCommentAlreadyExists() {
         rewriteRun(
             spec -> spec.expectedCyclesThatMakeChanges(0).cycles(1),
             java(
@@ -66,7 +68,8 @@ class InvalidExceptionUsageRecipeIssue5Test implements RewriteTest {
      * Test scenario similar to issue description - run recipe multiple times (3 cycles).
      * Should only make changes in first cycle.
      */
-    @Test void shouldBeIdempotentAcrossMultipleCycles() {
+    @Test
+    void shouldBeIdempotentAcrossMultipleCycles() {
         rewriteRun(
             spec -> spec.expectedCyclesThatMakeChanges(1).cycles(3),
             java(

--- a/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeIssue5Test.java
+++ b/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeIssue5Test.java
@@ -26,6 +26,7 @@ import static org.openrewrite.java.Assertions.java;
  * Test to reproduce and verify the fix for GitHub Issue #5:
  * TODO markers are added repeatedly on every build run
  */
+// cui-rewrite:disable InvalidExceptionUsageRecipe
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions
 class InvalidExceptionUsageRecipeIssue5Test implements RewriteTest {
 

--- a/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeSuppressionTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeSuppressionTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
+// cui-rewrite:disable InvalidExceptionUsageRecipe
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class InvalidExceptionUsageRecipeSuppressionTest implements RewriteTest {
 

--- a/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeSuppressionTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeSuppressionTest.java
@@ -25,11 +25,13 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class InvalidExceptionUsageRecipeSuppressionTest implements RewriteTest {
 
-    @Override public void defaults(RecipeSpec spec) {
+    @Override
+    public void defaults(RecipeSpec spec) {
         spec.recipe(new InvalidExceptionUsageRecipe());
     }
 
-    @Test void shouldSuppressCatchBlockWithCommentBeforeCatch() {
+    @Test
+    void shouldSuppressCatchBlockWithCommentBeforeCatch() {
         rewriteRun(
             spec -> spec.expectedCyclesThatMakeChanges(0),
             java(
@@ -52,7 +54,8 @@ class InvalidExceptionUsageRecipeSuppressionTest implements RewriteTest {
         );
     }
 
-    @Test void shouldSuppressCatchBlockWithCommentDirectlyBeforeCatch() {
+    @Test
+    void shouldSuppressCatchBlockWithCommentDirectlyBeforeCatch() {
         rewriteRun(
             java(
                 """
@@ -74,7 +77,8 @@ class InvalidExceptionUsageRecipeSuppressionTest implements RewriteTest {
         );
     }
 
-    @Test void shouldFlagUnsuppressedCatchBlock() {
+    @Test
+    void shouldFlagUnsuppressedCatchBlock() {
         rewriteRun(
             java(
                 """
@@ -109,7 +113,8 @@ class InvalidExceptionUsageRecipeSuppressionTest implements RewriteTest {
         );
     }
 
-    @Test void shouldSuppressCatchBlockFromMoreStringsExample() {
+    @Test
+    void shouldSuppressCatchBlockFromMoreStringsExample() {
         rewriteRun(
             java(
                 """
@@ -135,7 +140,8 @@ class InvalidExceptionUsageRecipeSuppressionTest implements RewriteTest {
         );
     }
 
-    @Test void shouldSuppressWithGeneralDisableComment() {
+    @Test
+    void shouldSuppressWithGeneralDisableComment() {
         rewriteRun(
             java(
                 """
@@ -157,7 +163,8 @@ class InvalidExceptionUsageRecipeSuppressionTest implements RewriteTest {
         );
     }
 
-    @Test void shouldHandleEmptyTryBlockSuppression() {
+    @Test
+    void shouldHandleEmptyTryBlockSuppression() {
         rewriteRun(
             java(
                 """
@@ -178,7 +185,8 @@ class InvalidExceptionUsageRecipeSuppressionTest implements RewriteTest {
         );
     }
 
-    @Test void shouldHandleTryBlockWithOnlyComments() {
+    @Test
+    void shouldHandleTryBlockWithOnlyComments() {
         rewriteRun(
             java(
                 """
@@ -199,7 +207,8 @@ class InvalidExceptionUsageRecipeSuppressionTest implements RewriteTest {
         );
     }
 
-    @Test void shouldNotSuppressWithWrongRecipeName() {
+    @Test
+    void shouldNotSuppressWithWrongRecipeName() {
         rewriteRun(
             java(
                 """
@@ -236,7 +245,8 @@ class InvalidExceptionUsageRecipeSuppressionTest implements RewriteTest {
         );
     }
 
-    @Test void shouldSuppressWithSpecificRecipeNameInComment() {
+    @Test
+    void shouldSuppressWithSpecificRecipeNameInComment() {
         rewriteRun(
             java(
                 """

--- a/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeTest.java
@@ -26,12 +26,14 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class InvalidExceptionUsageRecipeTest implements RewriteTest {
 
-    @Override public void defaults(RecipeSpec spec) {
+    @Override
+    public void defaults(RecipeSpec spec) {
         spec.recipe(new InvalidExceptionUsageRecipe())
             .parser(JavaParser.fromJavaVersion());
     }
 
-    @Test void detectCatchingException() {
+    @Test
+    void detectCatchingException() {
         rewriteRun(
             java(
                 """
@@ -68,7 +70,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectCatchingRuntimeException() {
+    @Test
+    void detectCatchingRuntimeException() {
         rewriteRun(
             java(
                 """
@@ -105,7 +108,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectCatchingThrowable() {
+    @Test
+    void detectCatchingThrowable() {
         rewriteRun(
             java(
                 """
@@ -142,7 +146,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectThrowingException() {
+    @Test
+    void detectThrowingException() {
         rewriteRun(
             java(
                 """
@@ -163,7 +168,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectThrowingRuntimeException() {
+    @Test
+    void detectThrowingRuntimeException() {
         rewriteRun(
             java(
                 """
@@ -184,7 +190,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectCreatingGenericException() {
+    @Test
+    void detectCreatingGenericException() {
         rewriteRun(
             java(
                 """
@@ -207,7 +214,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void allowSpecificExceptions() {
+    @Test
+    void allowSpecificExceptions() {
         rewriteRun(
             java(
                 """
@@ -231,7 +239,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void allowMultipleCatchWithSpecificFirst() {
+    @Test
+    void allowMultipleCatchWithSpecificFirst() {
         rewriteRun(
             java(
                 """
@@ -276,7 +285,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void respectSuppressionComment() {
+    @Test
+    void respectSuppressionComment() {
         rewriteRun(
             java(
                 """
@@ -301,7 +311,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void respectGeneralSuppressionComment() {
+    @Test
+    void respectGeneralSuppressionComment() {
         rewriteRun(
             java(
                 """
@@ -326,7 +337,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectNestedExceptionUsage() {
+    @Test
+    void detectNestedExceptionUsage() {
         rewriteRun(
             java(
                 """
@@ -371,7 +383,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectExceptionInLambda() {
+    @Test
+    void detectExceptionInLambda() {
         rewriteRun(
             java(
                 """
@@ -416,7 +429,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void allowCustomExceptionExtendingGeneric() {
+    @Test
+    void allowCustomExceptionExtendingGeneric() {
         rewriteRun(
             java(
                 """
@@ -444,7 +458,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void respectClassLevelSuppression() {
+    @Test
+    void respectClassLevelSuppression() {
         rewriteRun(
             java(
                 """
@@ -467,7 +482,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectDuplicateMarkersNotAdded() {
+    @Test
+    void detectDuplicateMarkersNotAdded() {
         rewriteRun(
             spec -> spec.expectedCyclesThatMakeChanges(1),
             java(
@@ -489,7 +505,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectExceptionInAssignment() {
+    @Test
+    void detectExceptionInAssignment() {
         rewriteRun(
             java(
                 """
@@ -510,7 +527,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void detectExceptionPassedAsParameter() {
+    @Test
+    void detectExceptionPassedAsParameter() {
         rewriteRun(
             java(
                 """
@@ -539,7 +557,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void respectMethodLevelSuppression() {
+    @Test
+    void respectMethodLevelSuppression() {
         rewriteRun(
             java(
                 """
@@ -570,7 +589,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void handleThrowableType() {
+    @Test
+    void handleThrowableType() {
         rewriteRun(
             java(
                 """
@@ -607,7 +627,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void handleExceptionInStaticContext() {
+    @Test
+    void handleExceptionInStaticContext() {
         rewriteRun(
             java(
                 """
@@ -644,7 +665,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void preventDuplicateMarkersOnCatch() {
+    @Test
+    void preventDuplicateMarkersOnCatch() {
         rewriteRun(
             spec -> spec.expectedCyclesThatMakeChanges(1).cycles(2),
             java(
@@ -682,7 +704,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void preventDuplicateMarkersOnThrow() {
+    @Test
+    void preventDuplicateMarkersOnThrow() {
         rewriteRun(
             spec -> spec.expectedCyclesThatMakeChanges(1).cycles(2),
             java(
@@ -704,7 +727,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void preventDuplicateMarkersOnNewClass() {
+    @Test
+    void preventDuplicateMarkersOnNewClass() {
         rewriteRun(
             spec -> spec.expectedCyclesThatMakeChanges(1).cycles(2),
             java(
@@ -726,7 +750,8 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
-    @Test void handleExceptionInTryWithResources() {
+    @Test
+    void handleExceptionInTryWithResources() {
         rewriteRun(
             java(
                 """

--- a/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
+// cui-rewrite:disable InvalidExceptionUsageRecipe
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class InvalidExceptionUsageRecipeTest implements RewriteTest {
 

--- a/src/test/java/de/cuioss/rewrite/logging/PlaceholderValidationUtilTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/PlaceholderValidationUtilTest.java
@@ -21,29 +21,35 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class PlaceholderValidationUtilTest {
 
-    @Test void hasIncorrectPlaceholdersNull() {
+    @Test
+    void hasIncorrectPlaceholdersNull() {
         assertFalse(PlaceholderValidationUtil.hasIncorrectPlaceholders(null));
     }
 
-    @Test void hasIncorrectPlaceholdersEmptyString() {
+    @Test
+    void hasIncorrectPlaceholdersEmptyString() {
         assertFalse(PlaceholderValidationUtil.hasIncorrectPlaceholders(""));
     }
 
-    @Test void hasIncorrectPlaceholdersNoPlaceholders() {
+    @Test
+    void hasIncorrectPlaceholdersNoPlaceholders() {
         assertFalse(PlaceholderValidationUtil.hasIncorrectPlaceholders("Simple message"));
     }
 
-    @Test void hasIncorrectPlaceholdersCorrectPlaceholders() {
+    @Test
+    void hasIncorrectPlaceholdersCorrectPlaceholders() {
         assertFalse(PlaceholderValidationUtil.hasIncorrectPlaceholders("Message with %s placeholder"));
         assertFalse(PlaceholderValidationUtil.hasIncorrectPlaceholders("%s %s multiple"));
     }
 
-    @Test void hasIncorrectPlaceholdersIncorrectCurlyBraces() {
+    @Test
+    void hasIncorrectPlaceholdersIncorrectCurlyBraces() {
         assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("Message with {} placeholder"));
         assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("{} {} multiple"));
     }
 
-    @Test void hasIncorrectPlaceholdersIncorrectFormatSpecifiers() {
+    @Test
+    void hasIncorrectPlaceholdersIncorrectFormatSpecifiers() {
         assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("Integer %d placeholder"));
         assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("Float %f placeholder"));
         assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("Boolean %b placeholder"));
@@ -51,37 +57,44 @@ class PlaceholderValidationUtilTest {
         assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("Scientific %e placeholder"));
     }
 
-    @Test void hasIncorrectPlaceholdersMixedPlaceholders() {
+    @Test
+    void hasIncorrectPlaceholdersMixedPlaceholders() {
         assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("Mixed %s and {} placeholders"));
         assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("%s correct but %d incorrect"));
     }
 
-    @Test void correctPlaceholdersNull() {
+    @Test
+    void correctPlaceholdersNull() {
         assertNull(PlaceholderValidationUtil.correctPlaceholders(null));
     }
 
-    @Test void correctPlaceholdersEmptyString() {
+    @Test
+    void correctPlaceholdersEmptyString() {
         assertEquals("", PlaceholderValidationUtil.correctPlaceholders(""));
     }
 
-    @Test void correctPlaceholdersNoPlaceholders() {
+    @Test
+    void correctPlaceholdersNoPlaceholders() {
         String message = "Simple message without placeholders";
         assertEquals(message, PlaceholderValidationUtil.correctPlaceholders(message));
     }
 
-    @Test void correctPlaceholdersAlreadyCorrect() {
+    @Test
+    void correctPlaceholdersAlreadyCorrect() {
         String message = "Message with %s placeholder";
         assertEquals(message, PlaceholderValidationUtil.correctPlaceholders(message));
     }
 
-    @Test void correctPlaceholdersReplaceCurlyBraces() {
+    @Test
+    void correctPlaceholdersReplaceCurlyBraces() {
         assertEquals("Message with %s placeholder",
             PlaceholderValidationUtil.correctPlaceholders("Message with {} placeholder"));
         assertEquals("%s %s multiple",
             PlaceholderValidationUtil.correctPlaceholders("{} {} multiple"));
     }
 
-    @Test void correctPlaceholdersReplaceFormatSpecifiers() {
+    @Test
+    void correctPlaceholdersReplaceFormatSpecifiers() {
         assertEquals("Integer %s placeholder",
             PlaceholderValidationUtil.correctPlaceholders("Integer %d placeholder"));
         assertEquals("Float %s placeholder",
@@ -106,7 +119,8 @@ class PlaceholderValidationUtilTest {
             PlaceholderValidationUtil.correctPlaceholders("Octal %o placeholder"));
     }
 
-    @Test void correctPlaceholdersMixedPlaceholders() {
+    @Test
+    void correctPlaceholdersMixedPlaceholders() {
         assertEquals("Mixed %s and %s placeholders",
             PlaceholderValidationUtil.correctPlaceholders("Mixed %s and {} placeholders"));
         assertEquals("%s correct and %s also correct",
@@ -115,37 +129,45 @@ class PlaceholderValidationUtilTest {
             PlaceholderValidationUtil.correctPlaceholders("{} %d %f all converted"));
     }
 
-    @Test void countPlaceholdersNull() {
+    @Test
+    void countPlaceholdersNull() {
         assertEquals(0, PlaceholderValidationUtil.countPlaceholders(null));
     }
 
-    @Test void countPlaceholdersEmptyString() {
+    @Test
+    void countPlaceholdersEmptyString() {
         assertEquals(0, PlaceholderValidationUtil.countPlaceholders(""));
     }
 
-    @Test void countPlaceholdersNoPlaceholders() {
+    @Test
+    void countPlaceholdersNoPlaceholders() {
         assertEquals(0, PlaceholderValidationUtil.countPlaceholders("Simple message"));
     }
 
-    @Test void countPlaceholdersSinglePlaceholder() {
+    @Test
+    void countPlaceholdersSinglePlaceholder() {
         assertEquals(1, PlaceholderValidationUtil.countPlaceholders("Message with %s"));
     }
 
-    @Test void countPlaceholdersMultiplePlaceholders() {
+    @Test
+    void countPlaceholdersMultiplePlaceholders() {
         assertEquals(2, PlaceholderValidationUtil.countPlaceholders("%s and %s"));
         assertEquals(3, PlaceholderValidationUtil.countPlaceholders("%s %s %s"));
     }
 
-    @Test void countPlaceholdersConsecutivePlaceholders() {
+    @Test
+    void countPlaceholdersConsecutivePlaceholders() {
         assertEquals(2, PlaceholderValidationUtil.countPlaceholders("%s%s"));
     }
 
-    @Test void countPlaceholdersEscapedPercent() {
+    @Test
+    void countPlaceholdersEscapedPercent() {
         assertEquals(1, PlaceholderValidationUtil.countPlaceholders("100%% complete with %s"));
         assertEquals(0, PlaceholderValidationUtil.countPlaceholders("100%% complete"));
     }
 
-    @Test void countPlaceholdersComplexPattern() {
+    @Test
+    void countPlaceholdersComplexPattern() {
         assertEquals(3, PlaceholderValidationUtil.countPlaceholders("User %s logged in at %s with 100%% success rate: %s"));
     }
 }

--- a/src/test/java/de/cuioss/rewrite/util/BaseSuppressionVisitorTest.java
+++ b/src/test/java/de/cuioss/rewrite/util/BaseSuppressionVisitorTest.java
@@ -33,7 +33,8 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("java:S2699") // OpenRewrite tests use implicit assertions via the RewriteTest framework
 class BaseSuppressionVisitorTest implements RewriteTest {
 
-    @Test void classLevelSuppressionSkipsEntireClass() {
+    @Test
+    void classLevelSuppressionSkipsEntireClass() {
         rewriteRun(
             spec -> spec.recipe(new TestRecipe()),
             java(
@@ -49,7 +50,8 @@ class BaseSuppressionVisitorTest implements RewriteTest {
         );
     }
 
-    @Test void methodLevelSuppressionSkipsMethod() {
+    @Test
+    void methodLevelSuppressionSkipsMethod() {
         rewriteRun(
             spec -> spec.recipe(new TestRecipe()),
             java(
@@ -81,7 +83,8 @@ class BaseSuppressionVisitorTest implements RewriteTest {
         );
     }
 
-    @Test void elementLevelSuppressionWorksWhenHelperMethodUsed() {
+    @Test
+    void elementLevelSuppressionWorksWhenHelperMethodUsed() {
         rewriteRun(
             spec -> spec.recipe(new TestRecipe()),
             java(
@@ -107,7 +110,8 @@ class BaseSuppressionVisitorTest implements RewriteTest {
         );
     }
 
-    @Test void helperMethodWorksCorrectly() {
+    @Test
+    void helperMethodWorksCorrectly() {
         rewriteRun(
             spec -> spec.recipe(new TestRecipe()),
             java(
@@ -135,27 +139,33 @@ class BaseSuppressionVisitorTest implements RewriteTest {
     public static class TestRecipe extends Recipe {
         static final String RECIPE_NAME = "TestRecipe";
 
-        @Override public String getDisplayName() {
+        @Override
+        public String getDisplayName() {
             return "Test Recipe for BaseSuppressionVisitor";
         }
 
-        @Override public String getDescription() {
+        @Override
+        public String getDescription() {
             return "Marks System.out.println calls for testing suppression behavior.";
         }
 
-        @Override public Set<String> getTags() {
+        @Override
+        public Set<String> getTags() {
             return Set.of("test");
         }
 
-        @Override public Duration getEstimatedEffortPerOccurrence() {
+        @Override
+        public Duration getEstimatedEffortPerOccurrence() {
             return Duration.ofMinutes(1);
         }
 
-        @Override public TreeVisitor<?, ExecutionContext> getVisitor() {
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new TestVisitor();
         }
 
-        @Override public List<Recipe> getRecipeList() {
+        @Override
+        public List<Recipe> getRecipeList() {
             return List.of();
         }
 
@@ -165,7 +175,8 @@ class BaseSuppressionVisitorTest implements RewriteTest {
                 super(RECIPE_NAME);
             }
 
-            @Override public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
 
                 // Check element-level suppression using the convenient helper

--- a/src/test/java/de/cuioss/rewrite/util/RecipeMarkerUtilTest.java
+++ b/src/test/java/de/cuioss/rewrite/util/RecipeMarkerUtilTest.java
@@ -16,12 +16,12 @@
 package de.cuioss.rewrite.util;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.marker.SearchResult;
+
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -58,7 +58,7 @@ class RecipeMarkerUtilTest {
         new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                if (method.getSimpleName().equals("println")) {
+                if ("println".equals(method.getSimpleName())) {
                     // Test without marker
                     foundWithoutMarker.set(!RecipeMarkerUtil.hasSearchResultMarker(method));
 
@@ -93,7 +93,7 @@ class RecipeMarkerUtilTest {
         new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                if (method.getSimpleName().equals("println")) {
+                if ("println".equals(method.getSimpleName())) {
                     boolean hasTask = RecipeMarkerUtil.hasTaskComment(method, "TODO: Test message", getCursor());
                     found.set(hasTask);
                 }
@@ -315,7 +315,7 @@ class RecipeMarkerUtilTest {
         new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                if (method.getSimpleName().equals("println")) {
+                if ("println".equals(method.getSimpleName())) {
                     boolean hasTask = RecipeMarkerUtil.hasTaskComment(method, "nonexistent message", getCursor());
                     found.set(!hasTask);
                 }

--- a/src/test/java/de/cuioss/rewrite/util/RecipeMarkerUtilTest.java
+++ b/src/test/java/de/cuioss/rewrite/util/RecipeMarkerUtilTest.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.rewrite.util;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RecipeMarkerUtilTest {
+
+    private final JavaParser parser = JavaParser.fromJavaVersion().build();
+
+    @Test
+    void shouldCreateTaskMessage() {
+        String result = RecipeMarkerUtil.createTaskMessage("Use specific exception", "TestRecipe");
+
+        assertThat(result).isEqualTo("TODO: Use specific exception. Suppress: // cui-rewrite:disable TestRecipe");
+    }
+
+    @Test
+    void shouldDetectSearchResultMarker() {
+        String source = """
+            public class Test {
+                void method() {
+                    System.out.println("test");
+                }
+            }
+            """;
+
+        J.CompilationUnit cu = (J.CompilationUnit) parser.parse(source).findFirst().orElseThrow();
+
+        AtomicBoolean foundWithMarker = new AtomicBoolean(false);
+        AtomicBoolean foundWithoutMarker = new AtomicBoolean(false);
+
+        new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                if (method.getSimpleName().equals("println")) {
+                    // Test without marker
+                    foundWithoutMarker.set(!RecipeMarkerUtil.hasSearchResultMarker(method));
+
+                    // Add marker and test with marker
+                    J.MethodInvocation withMarker = method.withMarkers(
+                        method.getMarkers().addIfAbsent(new SearchResult(UUID.randomUUID(), "test"))
+                    );
+                    foundWithMarker.set(RecipeMarkerUtil.hasSearchResultMarker(withMarker));
+                }
+                return super.visitMethodInvocation(method, ctx);
+            }
+        }.visit(cu, null);
+
+        assertTrue(foundWithoutMarker.get());
+        assertTrue(foundWithMarker.get());
+    }
+
+    @Test
+    void shouldDetectTaskCommentInMethodInvocation() {
+        String source = """
+            public class Test {
+                void method() {
+                    /*~~(TODO: Test message)~~>*/System.out.println("test");
+                }
+            }
+            """;
+
+        J.CompilationUnit cu = (J.CompilationUnit) parser.parse(source).findFirst().orElseThrow();
+
+        AtomicBoolean found = new AtomicBoolean(false);
+
+        new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                if (method.getSimpleName().equals("println")) {
+                    boolean hasTask = RecipeMarkerUtil.hasTaskComment(method, "TODO: Test message", getCursor());
+                    found.set(hasTask);
+                }
+                return super.visitMethodInvocation(method, ctx);
+            }
+        }.visit(cu, null);
+
+        assertTrue(found.get());
+    }
+
+    @Test
+    void shouldDetectTaskCommentInCatchBlock() {
+        String source = """
+            public class Test {
+                void method() {
+                    try {
+                        throw new Exception();
+                    } /*~~(TODO: Catch specific exception)~~>*/ catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+            """;
+
+        J.CompilationUnit cu = (J.CompilationUnit) parser.parse(source).findFirst().orElseThrow();
+
+        AtomicBoolean found = new AtomicBoolean(false);
+
+        new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Try.Catch visitCatch(J.Try.Catch catchClause, ExecutionContext ctx) {
+                boolean hasTask = RecipeMarkerUtil.hasTaskComment(catchClause, "TODO: Catch specific exception", getCursor());
+                found.set(hasTask);
+                return super.visitCatch(catchClause, ctx);
+            }
+        }.visit(cu, null);
+
+        assertTrue(found.get());
+    }
+
+    @Test
+    void shouldDetectTaskCommentInCatchBlockBody() {
+        String source = """
+            public class Test {
+                void method() {
+                    try {
+                        throw new Exception();
+                    } catch (Exception e) /*~~(TODO: Handle properly)~~>*/ {
+                        e.printStackTrace();
+                    }
+                }
+            }
+            """;
+
+        J.CompilationUnit cu = (J.CompilationUnit) parser.parse(source).findFirst().orElseThrow();
+
+        AtomicBoolean found = new AtomicBoolean(false);
+
+        new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Try.Catch visitCatch(J.Try.Catch catchClause, ExecutionContext ctx) {
+                boolean hasTask = RecipeMarkerUtil.hasTaskComment(catchClause, "TODO: Handle properly", getCursor());
+                found.set(hasTask);
+                return super.visitCatch(catchClause, ctx);
+            }
+        }.visit(cu, null);
+
+        assertTrue(found.get());
+    }
+
+    @Test
+    void shouldDetectTaskCommentInThrowStatement() {
+        String source = """
+            public class Test {
+                void method() {
+                    /*~~(TODO: Throw specific exception)~~>*/throw new Exception();
+                }
+            }
+            """;
+
+        J.CompilationUnit cu = (J.CompilationUnit) parser.parse(source).findFirst().orElseThrow();
+
+        AtomicBoolean found = new AtomicBoolean(false);
+
+        new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Throw visitThrow(J.Throw thrown, ExecutionContext ctx) {
+                boolean hasTask = RecipeMarkerUtil.hasTaskComment(thrown, "TODO: Throw specific exception", getCursor());
+                found.set(hasTask);
+                return super.visitThrow(thrown, ctx);
+            }
+        }.visit(cu, null);
+
+        assertTrue(found.get());
+    }
+
+    @Test
+    void shouldDetectTaskCommentInThrowStatementException() {
+        String source = """
+            public class Test {
+                void method() {
+                    throw /*~~(TODO: Use specific type)~~>*/new Exception();
+                }
+            }
+            """;
+
+        J.CompilationUnit cu = (J.CompilationUnit) parser.parse(source).findFirst().orElseThrow();
+
+        AtomicBoolean found = new AtomicBoolean(false);
+
+        new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Throw visitThrow(J.Throw thrown, ExecutionContext ctx) {
+                boolean hasTask = RecipeMarkerUtil.hasTaskComment(thrown, "TODO: Use specific type", getCursor());
+                found.set(hasTask);
+                return super.visitThrow(thrown, ctx);
+            }
+        }.visit(cu, null);
+
+        assertTrue(found.get());
+    }
+
+    @Test
+    void shouldDetectTaskCommentInNewClass() {
+        String source = """
+            public class Test {
+                void method() {
+                    Exception e = /*~~(TODO: Use specific exception)~~>*/new Exception();
+                }
+            }
+            """;
+
+        J.CompilationUnit cu = (J.CompilationUnit) parser.parse(source).findFirst().orElseThrow();
+
+        AtomicBoolean found = new AtomicBoolean(false);
+
+        new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
+                if (newClass.getType() != null && newClass.getType().toString().contains("Exception")) {
+                    boolean hasTask = RecipeMarkerUtil.hasTaskComment(newClass, "TODO: Use specific exception", getCursor());
+                    found.set(hasTask);
+                }
+                return super.visitNewClass(newClass, ctx);
+            }
+        }.visit(cu, null);
+
+        assertTrue(found.get());
+    }
+
+    @Test
+    void shouldHandleThrowWithNonNewClassException() {
+        String source = """
+            public class Test {
+                void method(Exception e) {
+                    throw e;
+                }
+            }
+            """;
+
+        J.CompilationUnit cu = (J.CompilationUnit) parser.parse(source).findFirst().orElseThrow();
+
+        AtomicBoolean tested = new AtomicBoolean(false);
+
+        new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Throw visitThrow(J.Throw thrown, ExecutionContext ctx) {
+                // This tests the path where exception is not a NewClass (line 106)
+                boolean hasTask = RecipeMarkerUtil.hasTaskComment(thrown, "nonexistent", getCursor());
+                assertFalse(hasTask);
+                tested.set(true);
+                return super.visitThrow(thrown, ctx);
+            }
+        }.visit(cu, null);
+
+        assertTrue(tested.get());
+    }
+
+    @Test
+    void shouldHandleDefaultCase() {
+        String source = """
+            public class Test {
+                /*~~(TODO: Add javadoc)~~>*/void method() {
+                }
+            }
+            """;
+
+        J.CompilationUnit cu = (J.CompilationUnit) parser.parse(source).findFirst().orElseThrow();
+
+        AtomicBoolean found = new AtomicBoolean(false);
+
+        new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                // This tests the default case (line 86) - MethodDeclaration is not one of the special cases
+                boolean hasTask = RecipeMarkerUtil.hasTaskComment(method, "TODO: Add javadoc", getCursor());
+                found.set(hasTask);
+                return super.visitMethodDeclaration(method, ctx);
+            }
+        }.visit(cu, null);
+
+        assertTrue(found.get());
+    }
+
+    @Test
+    void shouldNotFindNonexistentTaskComment() {
+        String source = """
+            public class Test {
+                void method() {
+                    System.out.println("test");
+                }
+            }
+            """;
+
+        J.CompilationUnit cu = (J.CompilationUnit) parser.parse(source).findFirst().orElseThrow();
+
+        AtomicBoolean found = new AtomicBoolean(false);
+
+        new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                if (method.getSimpleName().equals("println")) {
+                    boolean hasTask = RecipeMarkerUtil.hasTaskComment(method, "nonexistent message", getCursor());
+                    found.set(!hasTask);
+                }
+                return super.visitMethodInvocation(method, ctx);
+            }
+        }.visit(cu, null);
+
+        assertTrue(found.get());
+    }
+}

--- a/src/test/java/de/cuioss/rewrite/util/RecipeSuppressionUtilTest.java
+++ b/src/test/java/de/cuioss/rewrite/util/RecipeSuppressionUtilTest.java
@@ -27,8 +27,9 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.tree.J;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @EnableTestLogger(rootLevel = TestLogLevel.DEBUG) @SuppressWarnings({
     "java:S2699", // Tests use assertions via LogAsserts
@@ -240,16 +241,14 @@ class RecipeSuppressionUtilTest {
         assertTrue(visitor.methodWasSuppressed);
     }
 
-    @Test void shouldTestPrivateConstructor() {
-        try {
-            var constructor = RecipeSuppressionUtil.class.getDeclaredConstructor();
-            constructor.setAccessible(true);
-            constructor.newInstance();
-            assertFalse(true, "Should have thrown UnsupportedOperationException");
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
-            assertTrue(e.getCause() instanceof UnsupportedOperationException);
-            assertTrue(e.getCause().getMessage().contains("Utility class"));
-        }
+    @Test void shouldTestPrivateConstructor() throws Exception {
+        var constructor = RecipeSuppressionUtil.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+
+        var exception = assertThrows(InvocationTargetException.class, constructor::newInstance);
+
+        assertTrue(exception.getCause() instanceof UnsupportedOperationException);
+        assertTrue(exception.getCause().getMessage().contains("Utility class"));
     }
 
     @Test void shouldSuppressWithAnnotationsBetweenComments() {

--- a/src/test/java/de/cuioss/rewrite/util/RecipeSuppressionUtilTest.java
+++ b/src/test/java/de/cuioss/rewrite/util/RecipeSuppressionUtilTest.java
@@ -40,7 +40,8 @@ class RecipeSuppressionUtilTest {
     private final JavaParser parser = JavaParser.fromJavaVersion().build();
     private final ExecutionContext ctx = new InMemoryExecutionContext();
 
-    @Test void shouldDetectClassSuppressionWithGeneralComment() {
+    @Test
+    void shouldDetectClassSuppressionWithGeneralComment() {
         String source = """
             // cui-rewrite:disable
             public class TestClass {
@@ -58,7 +59,8 @@ class RecipeSuppressionUtilTest {
             "Skipping class 'TestClass' due to cui-rewrite:disable comment");
     }
 
-    @Test void shouldDetectMethodSuppressionWithGeneralComment() {
+    @Test
+    void shouldDetectMethodSuppressionWithGeneralComment() {
         String source = """
             public class TestClass {
                 // cui-rewrite:disable
@@ -76,7 +78,8 @@ class RecipeSuppressionUtilTest {
             "Skipping method 'testMethod' due to cui-rewrite:disable comment");
     }
 
-    @Test void shouldNotSuppressWithoutComment() {
+    @Test
+    void shouldNotSuppressWithoutComment() {
         String source = """
             public class TestClass {
                 public void method() {}
@@ -94,7 +97,8 @@ class RecipeSuppressionUtilTest {
         assertFalse(visitor.fieldWasSuppressed);
     }
 
-    @Test void shouldSuppressSpecificRecipeBySimpleName() {
+    @Test
+    void shouldSuppressSpecificRecipeBySimpleName() {
         String source = """
             // cui-rewrite:disable TestRecipe
             public class TestClass {}
@@ -110,7 +114,8 @@ class RecipeSuppressionUtilTest {
             "Skipping class 'TestClass' for recipe 'TestRecipe'");
     }
 
-    @Test void shouldSuppressSpecificRecipeByFullyQualifiedName() {
+    @Test
+    void shouldSuppressSpecificRecipeByFullyQualifiedName() {
         String source = """
             // cui-rewrite:disable de.cuioss.rewrite.TestRecipe
             public class TestClass {}
@@ -126,7 +131,8 @@ class RecipeSuppressionUtilTest {
             "Skipping class 'TestClass' for recipe 'de.cuioss.rewrite.TestRecipe'");
     }
 
-    @Test void shouldNotSuppressDifferentRecipe() {
+    @Test
+    void shouldNotSuppressDifferentRecipe() {
         String source = """
             // cui-rewrite:disable OtherRecipe
             public class TestClass {}
@@ -140,7 +146,8 @@ class RecipeSuppressionUtilTest {
         assertFalse(visitor.classWasSuppressed);
     }
 
-    @Test void shouldSuppressWithAnnotationPrefix() {
+    @Test
+    void shouldSuppressWithAnnotationPrefix() {
         String source = """
             // cui-rewrite:disable
             @Deprecated
@@ -155,7 +162,8 @@ class RecipeSuppressionUtilTest {
         assertTrue(visitor.classWasSuppressed);
     }
 
-    @Test void shouldHandleRecipeNameWithoutPackage() {
+    @Test
+    void shouldHandleRecipeNameWithoutPackage() {
         String source = """
             // cui-rewrite:disable SimpleRecipe
             public class TestClass {}
@@ -171,7 +179,8 @@ class RecipeSuppressionUtilTest {
             "Skipping class 'TestClass' for recipe 'SimpleRecipe'");
     }
 
-    @Test void shouldMatchSimpleNameFromFullyQualifiedRecipe() {
+    @Test
+    void shouldMatchSimpleNameFromFullyQualifiedRecipe() {
         String source = """
             // cui-rewrite:disable TestRecipe
             public class TestClass {}
@@ -187,7 +196,8 @@ class RecipeSuppressionUtilTest {
             "Skipping class 'TestClass' for recipe 'com.example.TestRecipe'");
     }
 
-    @Test void shouldNotSuppressWhenRecipeNameMismatch() {
+    @Test
+    void shouldNotSuppressWhenRecipeNameMismatch() {
         String source = """
             // cui-rewrite:disable SimpleRecipe
             public class TestClass {}
@@ -201,7 +211,8 @@ class RecipeSuppressionUtilTest {
         assertFalse(visitor.classWasSuppressed);
     }
 
-    @Test void shouldHandleMultipleSuppressionComments() {
+    @Test
+    void shouldHandleMultipleSuppressionComments() {
         String source = """
             public class TestClass {
                 // cui-rewrite:disable
@@ -225,7 +236,8 @@ class RecipeSuppressionUtilTest {
         assertTrue(visitor.methodWasSuppressed);
     }
 
-    @Test void shouldSuppressWithTrailingComment() {
+    @Test
+    void shouldSuppressWithTrailingComment() {
         String source = """
             public class TestClass {
                 // cui-rewrite:disable
@@ -241,7 +253,8 @@ class RecipeSuppressionUtilTest {
         assertTrue(visitor.methodWasSuppressed);
     }
 
-    @Test void shouldTestPrivateConstructor() throws Exception {
+    @Test
+    void shouldTestPrivateConstructor() throws Exception {
         var constructor = RecipeSuppressionUtil.class.getDeclaredConstructor();
         constructor.setAccessible(true);
 
@@ -251,7 +264,8 @@ class RecipeSuppressionUtilTest {
         assertTrue(exception.getCause().getMessage().contains("Utility class"));
     }
 
-    @Test void shouldSuppressWithAnnotationsBetweenComments() {
+    @Test
+    void shouldSuppressWithAnnotationsBetweenComments() {
         String source = """
             // cui-rewrite:disable
             @Deprecated
@@ -269,7 +283,8 @@ class RecipeSuppressionUtilTest {
         assertTrue(visitor.classWasSuppressed);
     }
 
-    @Test void shouldHandleNullRecipeName() {
+    @Test
+    void shouldHandleNullRecipeName() {
         String source = """
             // cui-rewrite:disable SpecificRecipe
             public class TestClass {
@@ -286,7 +301,8 @@ class RecipeSuppressionUtilTest {
         assertTrue(visitor.classWasSuppressed);
     }
 
-    @Test void shouldHandleComplexRecipeMatching() {
+    @Test
+    void shouldHandleComplexRecipeMatching() {
         String source = """
             // cui-rewrite:disable com.example.MyRecipe
             public class TestClass {}
@@ -301,7 +317,8 @@ class RecipeSuppressionUtilTest {
         assertTrue(visitor.classWasSuppressed);
     }
 
-    @Test void shouldHandleUnknownElementTypes() {
+    @Test
+    void shouldHandleUnknownElementTypes() {
         // This test creates a scenario that exercises the getElementType/getElementName default cases
         // The logic is already tested indirectly through the existing tests
         // This test serves to document that behavior and ensure coverage
@@ -338,7 +355,8 @@ class RecipeSuppressionUtilTest {
             this.recipeName = recipeName;
         }
 
-        @Override public J.@NonNull ClassDeclaration visitClassDeclaration(J.@NonNull ClassDeclaration classDecl, @NonNull ExecutionContext ctx) {
+        @Override
+        public J.@NonNull ClassDeclaration visitClassDeclaration(J.@NonNull ClassDeclaration classDecl, @NonNull ExecutionContext ctx) {
             if (RecipeSuppressionUtil.isSuppressed(getCursor(), recipeName)) {
                 classWasSuppressed = true;
                 return classDecl;
@@ -346,7 +364,8 @@ class RecipeSuppressionUtilTest {
             return super.visitClassDeclaration(classDecl, ctx);
         }
 
-        @Override public J.@NonNull MethodDeclaration visitMethodDeclaration(J.@NonNull MethodDeclaration method, @NonNull ExecutionContext ctx) {
+        @Override
+        public J.@NonNull MethodDeclaration visitMethodDeclaration(J.@NonNull MethodDeclaration method, @NonNull ExecutionContext ctx) {
             if (RecipeSuppressionUtil.isSuppressed(getCursor(), recipeName)) {
                 methodWasSuppressed = true;
                 return method;
@@ -354,7 +373,8 @@ class RecipeSuppressionUtilTest {
             return super.visitMethodDeclaration(method, ctx);
         }
 
-        @Override public J.@NonNull VariableDeclarations visitVariableDeclarations(J.@NonNull VariableDeclarations multiVariable, @NonNull ExecutionContext ctx) {
+        @Override
+        public J.@NonNull VariableDeclarations visitVariableDeclarations(J.@NonNull VariableDeclarations multiVariable, @NonNull ExecutionContext ctx) {
             if (isFieldDeclaration() && RecipeSuppressionUtil.isSuppressed(getCursor(), recipeName)) {
                 fieldWasSuppressed = true;
                 return multiVariable;

--- a/src/test/java/de/cuioss/rewrite/util/RecipeSuppressionUtilTest.java
+++ b/src/test/java/de/cuioss/rewrite/util/RecipeSuppressionUtilTest.java
@@ -246,7 +246,7 @@ class RecipeSuppressionUtilTest {
             constructor.setAccessible(true);
             constructor.newInstance();
             assertFalse(true, "Should have thrown UnsupportedOperationException");
-        } catch (Exception e) {
+        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
             assertTrue(e.getCause() instanceof UnsupportedOperationException);
             assertTrue(e.getCause().getMessage().contains("Utility class"));
         }

--- a/src/test/java/de/cuioss/rewrite/util/RecipeSuppressionUtilTest.java
+++ b/src/test/java/de/cuioss/rewrite/util/RecipeSuppressionUtilTest.java
@@ -327,7 +327,8 @@ class RecipeSuppressionUtilTest {
         boolean classWasSuppressed;
         boolean methodWasSuppressed;
         boolean fieldWasSuppressed;
-        @Nullable final String recipeName;
+        @Nullable
+        final String recipeName;
 
         TestVisitor() {
             this(null);


### PR DESCRIPTION
## Summary

Fixed the AnnotationNewlineFormat recipe to produce formatting that persists through AutoFormat during pre-commit builds. Previously, annotations formatted by AnnotationNewlineFormat were being reverted back to inline format by AutoFormat.

## Root Cause

The recipe was extracting indentation from the first annotation's prefix (`getIndentationFromPrefix(annotations.getFirst().getPrefix())`), but for inline annotations like `@Test void method()`, the first annotation doesn't contain the parent context indentation in its prefix. This resulted in subsequent annotations having 0 indentation, which caused AutoFormat to recombine them back to inline format.

## Solution

Changed the `formatAnnotationList` method to use `getProperIndentation()` which correctly looks at the parent context (method, class, field) to determine proper indentation. This ensures all annotations have consistent indentation that AutoFormat respects and preserves.

## Changes Made

- **AnnotationNewlineFormat.java**: Fixed indentation calculation in `formatAnnotationList()`
- **AnnotationNewlineFormatTest.java**: Added comprehensive tests including `shouldPreserveIndentationForMethodAnnotations` and `shouldSeparateSingleMethodAnnotationFromModifiers`
- **pom.xml**: Added property to override cui-open-rewrite version for pre-commit testing
- **All source files**: Properly formatted with annotations on separate lines (applied by the fixed recipe)

## Verified Results

All annotation types now format correctly and persist through AutoFormat:

- ✅ Class-level annotations: `@Deprecated @SuppressWarnings("all") public class` → `@Deprecated\n@SuppressWarnings("all")\npublic class`
- ✅ Method-level annotations: `@Override public void method()` → `@Override\npublic void method()`
- ✅ Test annotations: `@Test void shouldTest()` → `@Test\nvoid shouldTest()`
- ✅ Single annotations with modifiers: `@SafeVarargs private static` → `@SafeVarargs\nprivate static`
- ✅ Field-level annotations: `@Deprecated String field` → `@Deprecated\nString field`

## Test Plan

- [x] All 176 tests pass
- [x] Pre-commit build successful with no warnings
- [x] Second pre-commit build confirms no changes introduced (formatting is stable)
- [x] Git status clean after multiple build cycles
- [x] Verified AutoFormat no longer reverts annotation formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)