### PR TITLE
fix: Add PathExclusionVisitor to exclude target/build directories (#14)

### DIFF
--- a/src/main/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipe.java
@@ -16,6 +16,7 @@
 package de.cuioss.rewrite.logging;
 
 import de.cuioss.rewrite.util.BaseSuppressionVisitor;
+import de.cuioss.rewrite.util.PathExclusionVisitor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -69,7 +70,10 @@ public class CuiLogRecordPatternRecipe extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new IsLikelyNotTest(), new CuiLogRecordPatternVisitor());
+        return Preconditions.check(
+            new PathExclusionVisitor(),
+            Preconditions.check(new IsLikelyNotTest(), new CuiLogRecordPatternVisitor())
+        );
     }
 
     @Override

--- a/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
@@ -16,9 +16,11 @@
 package de.cuioss.rewrite.logging;
 
 import de.cuioss.rewrite.util.BaseSuppressionVisitor;
+import de.cuioss.rewrite.util.PathExclusionVisitor;
 import de.cuioss.rewrite.util.RecipeMarkerUtil;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.tree.Expression;
@@ -68,7 +70,7 @@ public class CuiLoggerStandardsRecipe extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new CuiLoggerStandardsVisitor();
+        return Preconditions.check(new PathExclusionVisitor(), new CuiLoggerStandardsVisitor());
     }
 
     @Override

--- a/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
@@ -15,10 +15,12 @@
  */
 package de.cuioss.rewrite.logging;
 
+import de.cuioss.rewrite.util.PathExclusionVisitor;
 import de.cuioss.rewrite.util.RecipeMarkerUtil;
 import de.cuioss.rewrite.util.RecipeSuppressionUtil;
 import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
@@ -81,7 +83,7 @@ public class InvalidExceptionUsageRecipe extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new InvalidExceptionUsageVisitor();
+        return Preconditions.check(new PathExclusionVisitor(), new InvalidExceptionUsageVisitor());
     }
 
     @Override

--- a/src/main/java/de/cuioss/rewrite/util/PathExclusionVisitor.java
+++ b/src/main/java/de/cuioss/rewrite/util/PathExclusionVisitor.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.rewrite.util;
+
+import de.cuioss.tools.logging.CuiLogger;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.marker.SearchResult;
+
+/**
+ * TreeVisitor that acts as a precondition to exclude source files matching specific path patterns.
+ * This visitor marks files that should NOT be processed by returning them without any marker.
+ * Only files that don't match exclusion patterns are marked for processing.
+ *
+ * <p>Default exclusions include target and build directories.</p>
+ *
+ * <p>Usage: Use with Preconditions.check() to filter files before applying recipes.</p>
+ */
+public class PathExclusionVisitor extends TreeVisitor<Tree, ExecutionContext> {
+
+    private static final CuiLogger LOGGER = new CuiLogger(PathExclusionVisitor.class);
+
+    /**
+     * Default exclusion patterns for common build output directories.
+     */
+    private static final String[] DEFAULT_EXCLUSIONS = {
+        "**/target/**",
+        "**/build/**"
+    };
+
+    private final String[] exclusionPatterns;
+
+    /**
+     * Creates a PathExclusionVisitor with default exclusions (target and build directories).
+     */
+    public PathExclusionVisitor() {
+        this(DEFAULT_EXCLUSIONS);
+    }
+
+    /**
+     * Creates a PathExclusionVisitor with custom exclusion patterns.
+     *
+     * @param exclusionPatterns glob patterns for paths to exclude
+     */
+    public PathExclusionVisitor(String... exclusionPatterns) {
+        this.exclusionPatterns = exclusionPatterns;
+    }
+
+    @Override
+    public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+        if (tree instanceof SourceFile sourceFile) {
+            String sourcePath = sourceFile.getSourcePath().toString();
+
+            // Normalize path separators to forward slashes for consistent pattern matching
+            sourcePath = sourcePath.replace('\\', '/');
+
+            LOGGER.trace("Checking path: %s", sourcePath);
+
+            for (String pattern : exclusionPatterns) {
+                LOGGER.trace("Against pattern: %s", pattern);
+                boolean matches = matchesGlobPattern(sourcePath, pattern);
+                LOGGER.trace("Matches: %s", matches);
+                if (matches) {
+                    // File matches exclusion pattern - return it unmarked so precondition fails
+                    LOGGER.debug("Excluding file from processing: %s", sourcePath);
+                    return sourceFile;
+                }
+            }
+
+            // File doesn't match any exclusion pattern - mark it so precondition passes
+            LOGGER.trace("Including file for processing: %s", sourcePath);
+            return SearchResult.found(sourceFile);
+        }
+        return super.visit(tree, ctx);
+    }
+
+    /**
+     * Simple glob pattern matching for paths.
+     * Supports ** for any number of directories and * for any characters within a segment.
+     *
+     * @param path the path to check
+     * @param pattern the glob pattern
+     * @return true if the path matches the pattern
+     */
+    private boolean matchesGlobPattern(String path, String pattern) {
+        // Simple implementation: For patterns like "**/target/**" or "**/build/**"
+        // check if the directory name appears as a path component
+        if (pattern.startsWith("**/") && pattern.endsWith("/**")) {
+            String dirName = pattern.substring(3, pattern.length() - 3);
+
+            // Check if path starts with "dirName/" or contains "/dirName/"
+            boolean matches = path.startsWith(dirName + "/") || path.contains("/" + dirName + "/");
+
+            LOGGER.trace("Path '%s' %s pattern '%s'", path, matches ? "matches" : "does not match", pattern);
+            return matches;
+        }
+
+        LOGGER.trace("Pattern '%s' not in expected format, skipping path '%s'", pattern, path);
+        return false;
+    }
+}

--- a/src/main/java/de/cuioss/rewrite/util/PathExclusionVisitor.java
+++ b/src/main/java/de/cuioss/rewrite/util/PathExclusionVisitor.java
@@ -16,12 +16,12 @@
 package de.cuioss.rewrite.util;
 
 import de.cuioss.tools.logging.CuiLogger;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.PathUtils;
 import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.SearchResult;
 
 import java.nio.file.Path;

--- a/src/test/java/de/cuioss/rewrite/util/PathExclusionVisitorTest.java
+++ b/src/test/java/de/cuioss/rewrite/util/PathExclusionVisitorTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.rewrite.util;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link PathExclusionVisitor} to ensure build output directories
+ * and generated code are properly excluded from recipe processing.
+ */
+class PathExclusionVisitorTest {
+
+    private final JavaParser parser = JavaParser.fromJavaVersion().build();
+    private final ExecutionContext ctx = new InMemoryExecutionContext();
+    private final PathExclusionVisitor visitor = new PathExclusionVisitor();
+
+    @Test
+    void shouldExcludeTargetDirectory() {
+        String source = "class GeneratedCode {}";
+        Path sourcePath = Path.of("target/generated-sources/annotations/GeneratedCode.java");
+        SourceFile sourceFile = parseWithPath(source, sourcePath);
+
+        SourceFile result = (SourceFile) visitor.visit(sourceFile, ctx);
+
+        assertFalse(result.getMarkers().findFirst(SearchResult.class).isPresent(),
+            "Files in target directory should NOT be marked (excluded)");
+    }
+
+    @Test
+    void shouldExcludeMavenTargetTestSources() {
+        String source = "class TestBenchmark_jmhTest {}";
+        Path sourcePath = Path.of("target/generated-test-sources/test-annotations/TestBenchmark_jmhTest.java");
+        SourceFile sourceFile = parseWithPath(source, sourcePath);
+
+        SourceFile result = (SourceFile) visitor.visit(sourceFile, ctx);
+
+        assertFalse(result.getMarkers().findFirst(SearchResult.class).isPresent(),
+            "JMH generated test sources should NOT be marked (excluded)");
+    }
+
+    @Test
+    void shouldExcludeGradleBuildDirectory() {
+        String source = "class BuildGenerated {}";
+        Path sourcePath = Path.of("build/generated/sources/annotationProcessor/java/main/BuildGenerated.java");
+        SourceFile sourceFile = parseWithPath(source, sourcePath);
+
+        SourceFile result = (SourceFile) visitor.visit(sourceFile, ctx);
+
+        assertFalse(result.getMarkers().findFirst(SearchResult.class).isPresent(),
+            "Files in build directory should NOT be marked (excluded)");
+    }
+
+    @Test
+    void shouldProcessRegularSourceFiles() {
+        String source = "class SourceCode {}";
+        Path sourcePath = Path.of("src/main/java/SourceCode.java");
+        SourceFile sourceFile = parseWithPath(source, sourcePath);
+
+        SourceFile result = (SourceFile) visitor.visit(sourceFile, ctx);
+
+        assertTrue(result.getMarkers().findFirst(SearchResult.class).isPresent(),
+            "Regular source files should be marked for processing");
+    }
+
+    @Test
+    void shouldProcessTestSourceFiles() {
+        String source = "class SourceTest {}";
+        Path sourcePath = Path.of("src/test/java/SourceTest.java");
+        SourceFile sourceFile = parseWithPath(source, sourcePath);
+
+        SourceFile result = (SourceFile) visitor.visit(sourceFile, ctx);
+
+        assertTrue(result.getMarkers().findFirst(SearchResult.class).isPresent(),
+            "Test source files should be marked for processing");
+    }
+
+    @Test
+    void shouldExcludeNestedTargetDirectories() {
+        String source = "class ModuleGenerated {}";
+        Path sourcePath = Path.of("module-a/target/classes/ModuleGenerated.java");
+        SourceFile sourceFile = parseWithPath(source, sourcePath);
+
+        SourceFile result = (SourceFile) visitor.visit(sourceFile, ctx);
+
+        assertFalse(result.getMarkers().findFirst(SearchResult.class).isPresent(),
+            "Nested target directories should NOT be marked (excluded)");
+    }
+
+    @Test
+    void shouldHandleWindowsStylePaths() {
+        String source = "class WindowsGenerated {}";
+        // Windows-style path
+        Path sourcePath = Path.of("target", "generated-sources", "annotations", "WindowsGenerated.java");
+        SourceFile sourceFile = parseWithPath(source, sourcePath);
+
+        SourceFile result = (SourceFile) visitor.visit(sourceFile, ctx);
+
+        assertFalse(result.getMarkers().findFirst(SearchResult.class).isPresent(),
+            "Windows-style paths in target should NOT be marked (excluded)");
+    }
+
+    @Test
+    void shouldExcludeTargetInAnyPosition() {
+        String source = "class BenchmarkGenerated {}";
+        Path sourcePath = Path.of("benchmarking/cui-benchmarking-common/target/generated-test-sources/test-annotations/BenchmarkGenerated.java");
+        SourceFile sourceFile = parseWithPath(source, sourcePath);
+
+        SourceFile result = (SourceFile) visitor.visit(sourceFile, ctx);
+
+        assertFalse(result.getMarkers().findFirst(SearchResult.class).isPresent(),
+            "Deep nested target paths should NOT be marked (excluded)");
+    }
+
+    private SourceFile parseWithPath(String source, Path sourcePath) {
+        List<SourceFile> sources = parser.parse(source).toList();
+        J.CompilationUnit cu = (J.CompilationUnit) sources.getFirst();
+        return cu.withSourcePath(sourcePath);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements `PathExclusionVisitor` to prevent recipes from processing generated code in target/build directories
- Fixes issue where TODO markers were being added to JMH-generated benchmark code
- Uses simple string matching to check for target/ or build/ directory components in paths

## Changes
- **New**: `PathExclusionVisitor` class with default exclusions for `**/target/**` and `**/build/**`
- **Modified**: `CuiLogRecordPatternRecipe`, `CuiLoggerStandardsRecipe`, `InvalidExceptionUsageRecipe` to use precondition
- **New**: Comprehensive unit tests covering various path scenarios

## Testing
- All 208 tests pass
- Pre-commit build successful
- 8 new unit tests for PathExclusionVisitor

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)