### PR TITLE
chore: upgrade OpenRewrite to 8.72.6 with Java 25 support

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -7,7 +7,7 @@ release:
   create-github-release: true
 
 maven-build:
-  java-versions: '["21"]'
+  java-versions: '["21","25"]'
   java-version: '21'
   enable-snapshot-deploy: true
   maven-profiles-snapshot: 'release-snapshot,javadoc'

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <maven.jar.plugin.automatic.module.name>de.cuioss.rewrite</maven.jar.plugin.automatic.module.name>
-        <openrewrite.version>8.61.2</openrewrite.version>
-        <openrewrite.maven.version>6.17.0</openrewrite.maven.version>
+        <openrewrite.version>8.72.6</openrewrite.version>
+        <openrewrite.maven.version>6.28.1</openrewrite.maven.version>
     </properties>
     <dependencies>
         <!-- OpenRewrite Core -->
@@ -43,10 +43,10 @@
             <version>${openrewrite.version}</version>
         </dependency>
 
-        <!-- Runtime dependency for Java 11+ support -->
+        <!-- Runtime dependency for Java 25+ support (fixes DocCommentTable incompatibility on JDK 23+) -->
         <dependency>
             <groupId>org.openrewrite</groupId>
-            <artifactId>rewrite-java-11</artifactId>
+            <artifactId>rewrite-java-25</artifactId>
             <version>${openrewrite.version}</version>
             <scope>runtime</scope>
         </dependency>

--- a/src/test/java/de/cuioss/rewrite/format/AnnotationNewlineFormatTest.java
+++ b/src/test/java/de/cuioss/rewrite/format/AnnotationNewlineFormatTest.java
@@ -462,7 +462,7 @@ class AnnotationNewlineFormatTest implements RewriteTest {
     void classAnnotationsShouldPersistThroughAutoFormat() {
         rewriteRun(
             spec -> spec.recipe(new AnnotationNewlineFormat())
-                .recipe(new AutoFormat())
+                .recipe(new AutoFormat(null))
                 .parser(JavaParser.fromJavaVersion()
                     .dependsOn(
                         """


### PR DESCRIPTION
## Summary
- Upgrade OpenRewrite from 8.61.2 to 8.72.6
- Replace `rewrite-java-11` with `rewrite-java-25` runtime parser
- Re-enable Java 25 in CI build matrix

## Motivation
The previous build failed on Java 24/25 with:
```
java.lang.NoSuchMethodError: 'com.sun.tools.javac.tree.DCTree$DCDocComment
  com.sun.tools.javac.tree.DocCommentTable.getCommentTree(com.sun.tools.javac.tree.JCTree)'
```

This was caused by `rewrite-java-11` being compiled against JDK 11 internal APIs that changed in JDK 23+. The new `rewrite-java-25` module is compiled against JDK 25 and handles the API change correctly.

See: https://github.com/openrewrite/rewrite/issues/6133

## Changes
| File | Change |
|------|--------|
| `pom.xml` | `openrewrite.version`: 8.61.2 → 8.72.6 |
| `pom.xml` | `openrewrite.maven.version`: 6.17.0 → 6.28.1 |
| `pom.xml` | `rewrite-java-11` → `rewrite-java-25` |
| `project.yml` | `java-versions`: `["21"]` → `["21","25"]` |