### PR TITLE
chore: prepare release 1.1.2

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,7 +2,7 @@ name: cui-open-rewrite
 description: CUI OpenRewrite recipes for Java modernization
 
 release:
-  current-version: 1.1.1
+  current-version: 1.1.2
   next-version: 1.1-SNAPSHOT
   create-github-release: true
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.cuioss</groupId>
         <artifactId>cui-java-parent</artifactId>
-        <version>1.2.5</version>
+        <version>1.4.0</version>
         <relativePath />
     </parent>
     <groupId>de.cuioss.rewrite</groupId>

--- a/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
@@ -452,7 +452,8 @@ public class CuiLoggerStandardsRecipe extends Recipe {
             }
         }
 
-        private record ExceptionPosition(int index, @Nullable Expression exception) {
+        private record ExceptionPosition(int index, @Nullable
+            Expression exception) {
 
             static ExceptionPosition notFound() {
                 return new ExceptionPosition(-1, null);

--- a/src/test/java/de/cuioss/rewrite/util/RecipeSuppressionUtilTest.java
+++ b/src/test/java/de/cuioss/rewrite/util/RecipeSuppressionUtilTest.java
@@ -31,7 +31,8 @@ import java.lang.reflect.InvocationTargetException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@EnableTestLogger(rootLevel = TestLogLevel.DEBUG) @SuppressWarnings({
+@EnableTestLogger(rootLevel = TestLogLevel.DEBUG)
+@SuppressWarnings({
     "java:S2699", // Tests use assertions via LogAsserts
     "java:S5976"  // Similar tests are intentionally kept separate for clarity
 })


### PR DESCRIPTION
## Summary
- Update `cui-java-parent` from 1.2.5 to 1.4.0
- Increment `release:current-version` to 1.1.2 in `.github/project.yml`
- Apply annotation newline formatting from OpenRewrite auto-format

## Test plan
- [x] `./mvnw -Ppre-commit clean install` passes (206 tests, 0 failures)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)