### PR TITLE
chore: remove deprecated auto-merge-build-timeout from project.yml

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -25,4 +25,3 @@ pages:
 
 github-automation:
   auto-merge-build-versions: true
-  auto-merge-build-timeout: 300


### PR DESCRIPTION
The `auto-merge-build-timeout` field is no longer used. The release workflow now uses `gh pr merge --auto` which delegates merge timing to GitHub natively.

See: https://github.com/cuioss/cuioss-organization/pull/58