### PR TITLE
fix: correct recipe edge cases (logger rename, multi-catch, placeholders, locale)

### DIFF
--- a/src/main/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipe.java
@@ -33,6 +33,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
@@ -485,8 +486,9 @@ public class CuiLogRecordPatternRecipe extends Recipe {
             TRACE, DEBUG, INFO, WARN, ERROR, FATAL;
 
             static Optional<LogLevel> fromMethodName(String methodName) {
-                // Convert method name to uppercase and try to match
-                String upperMethodName = methodName.toUpperCase();
+                // Convert method name to uppercase and try to match.
+                // Locale.ROOT avoids locale-sensitive casing (e.g. the Turkish dotted-I).
+                String upperMethodName = methodName.toUpperCase(Locale.ROOT);
                 try {
                     return Optional.of(LogLevel.valueOf(upperMethodName));
                 } catch (IllegalArgumentException e) {

--- a/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
@@ -23,10 +23,12 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.RenameVariable;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.marker.SearchResult;
@@ -151,28 +153,39 @@ public class CuiLoggerStandardsRecipe extends Recipe {
         }
 
         private J.VariableDeclarations checkLoggerNaming(J.VariableDeclarations vd) {
-            boolean needsRename = false;
-            String oldLoggerName = null;
-            List<J.VariableDeclarations.NamedVariable> updatedVariables = new ArrayList<>();
             for (J.VariableDeclarations.NamedVariable variable : vd.getVariables()) {
-                String name = variable.getSimpleName();
-                if (!LOGGER_NAME.equals(name)) {
-                    needsRename = true;
-                    oldLoggerName = name;
-                    // Rename the variable to LOGGER_NAME
-                    J.Identifier newName = variable.getName().withSimpleName(LOGGER_NAME);
-                    // Don't update type information - it causes LST errors
-                    variable = variable.withName(newName);
+                if (LOGGER_NAME.equals(variable.getSimpleName())) {
+                    continue;
                 }
-                updatedVariables.add(variable);
-            }
-            if (needsRename) {
-                vd = vd.withVariables(updatedVariables);
-                // Store the old name so we can update references
-                getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, "RENAMED_LOGGER", oldLoggerName);
-                // Auto-fixed, don't mark it
+                if (loggerNameCollision()) {
+                    // Another field named LOGGER already exists in this class; renaming would
+                    // produce a duplicate field. Flag it instead of generating invalid code.
+                    String message = RecipeMarkerUtil.createTaskMessage(
+                        "Rename logger to LOGGER (name already in use)", RECIPE_NAME);
+                    return vd.withMarkers(vd.getMarkers().addIfAbsent(new SearchResult(randomId(), message)));
+                }
+                // Delegate the rename to RenameVariable so that every reference form
+                // (this.log, log passed as an argument, initializers, nested classes) is updated.
+                doAfterVisit(new RenameVariable<>(variable, LOGGER_NAME));
             }
             return vd;
+        }
+
+        private boolean loggerNameCollision() {
+            J.ClassDeclaration enclosingClass = getCursor().firstEnclosing(J.ClassDeclaration.class);
+            if (enclosingClass == null) {
+                return false;
+            }
+            for (Statement statement : enclosingClass.getBody().getStatements()) {
+                if (statement instanceof J.VariableDeclarations other) {
+                    for (J.VariableDeclarations.NamedVariable variable : other.getVariables()) {
+                        if (LOGGER_NAME.equals(variable.getSimpleName())) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
         }
 
         private J.VariableDeclarations checkLoggerModifiers(J.VariableDeclarations vd) {
@@ -236,7 +249,9 @@ public class CuiLoggerStandardsRecipe extends Recipe {
                 );
                 newModifiers.add(finalMod);
 
-                // Add back other modifiers (annotations, etc.)
+                // Only visibility, static and final are normalized. Any additional modifiers
+                // (e.g. transient, volatile) are appended after final in their original relative
+                // order, which is consistent with the JLS ordering where they follow final.
                 newModifiers.addAll(otherModifiers);
 
                 vd = vd.withModifiers(newModifiers);
@@ -267,13 +282,6 @@ public class CuiLoggerStandardsRecipe extends Recipe {
             mi = checkSystemStreams(mi);
             if (RecipeMarkerUtil.hasSearchResultMarker(mi)) {
                 return mi;
-            }
-
-            // Check if we need to rename logger references
-            String renamedLogger = getCursor().getNearestMessage("RENAMED_LOGGER");
-            if (renamedLogger != null && mi.getSelect() instanceof J.Identifier select
-                && renamedLogger.equals(select.getSimpleName())) {
-                mi = mi.withSelect(select.withSimpleName(LOGGER_NAME));
             }
 
             // Check logger method invocations

--- a/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
@@ -18,6 +18,7 @@ package de.cuioss.rewrite.logging;
 import de.cuioss.rewrite.util.PathExclusionVisitor;
 import de.cuioss.rewrite.util.RecipeMarkerUtil;
 import de.cuioss.rewrite.util.RecipeSuppressionUtil;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
@@ -210,26 +211,47 @@ public class InvalidExceptionUsageRecipe extends Recipe {
                 return c;
             }
 
-            // Check the caught exception type
+            // Check the caught exception type. A multi-catch (catch (A | B e)) has a
+            // JavaType.MultiCatch union type, so each alternative must be inspected individually.
             J.ControlParentheses<J.VariableDeclarations> parameterParens = c.getParameter();
             J.VariableDeclarations parameter = parameterParens.getTree();
-            if (parameter.getType() != null) {
-                JavaType type = parameter.getType();
-                JavaType.FullyQualified fqType = TypeUtils.asFullyQualified(type);
+            String simpleType = findGenericExceptionSimpleName(parameter.getType());
+            if (simpleType != null) {
+                String taskMessage = createTaskMessage("Catch", simpleType);
 
-                if (fqType != null && GENERIC_EXCEPTION_TYPES.contains(fqType.getFullyQualifiedName())) {
-                    String simpleType = fqType.getClassName();
-                    String taskMessage = createTaskMessage("Catch", simpleType);
-
-                    // Check if this comment already exists (from a previous run)
-                    if (RecipeMarkerUtil.hasTaskComment(c, taskMessage, getCursor()) || RecipeMarkerUtil.hasSearchResultMarker(c)) {
-                        return c;
-                    }
-                    return SearchResult.found(c, taskMessage);
+                // Check if this comment already exists (from a previous run)
+                if (RecipeMarkerUtil.hasTaskComment(c, taskMessage, getCursor()) || RecipeMarkerUtil.hasSearchResultMarker(c)) {
+                    return c;
                 }
+                return SearchResult.found(c, taskMessage);
             }
 
             return c;
+        }
+
+        /**
+         * Returns the simple name of the first generic exception type in the given type, or
+         * {@code null} if none is generic. Handles both single catch types and multi-catch unions.
+         */
+        private @Nullable String findGenericExceptionSimpleName(@Nullable JavaType type) {
+            if (type instanceof JavaType.MultiCatch multiCatch) {
+                for (JavaType alternative : multiCatch.getThrowableTypes()) {
+                    String simpleName = genericSimpleNameOf(alternative);
+                    if (simpleName != null) {
+                        return simpleName;
+                    }
+                }
+                return null;
+            }
+            return genericSimpleNameOf(type);
+        }
+
+        private @Nullable String genericSimpleNameOf(@Nullable JavaType type) {
+            JavaType.FullyQualified fqType = TypeUtils.asFullyQualified(type);
+            if (fqType != null && GENERIC_EXCEPTION_TYPES.contains(fqType.getFullyQualifiedName())) {
+                return fqType.getClassName();
+            }
+            return null;
         }
 
         @Override

--- a/src/main/java/de/cuioss/rewrite/logging/PlaceholderValidationUtil.java
+++ b/src/main/java/de/cuioss/rewrite/logging/PlaceholderValidationUtil.java
@@ -23,26 +23,39 @@ import java.util.regex.Pattern;
 /**
  * Utility class for validating and correcting placeholder patterns in logging messages.
  * <p>
- * CUI logging standards require the use of %s placeholders exclusively.
+ * CUI logging standards require the use of {@code %s} placeholders exclusively.
  * This utility detects and can correct:
- * - SLF4J-style {} placeholders
- * - Printf-style placeholders like %d, %f, %x, etc.
- * </p>
+ * <ul>
+ *   <li>SLF4J-style {@code {}} placeholders</li>
+ *   <li>Any printf-style conversion other than {@code %s} — including width, precision,
+ *       flags and argument-index forms such as {@code %d}, {@code %5d}, {@code %.2f},
+ *       {@code %08x}, {@code %,d}, {@code %1$s} and {@code %n}</li>
+ * </ul>
+ * <p>
+ * The literal-percent escape {@code %%} is recognised and left untouched, so a message such
+ * as {@code "100%% done"} is neither flagged nor rewritten, and {@code "%%d"} keeps its escape
+ * instead of being corrupted into {@code "%%s"}.
  */
 public final class PlaceholderValidationUtil {
 
     /**
-     * Pattern for correct CUI placeholder (%s)
+     * Matches a single printf-style format directive left-to-right:
+     * either the literal-percent escape {@code %%}, or a conversion with an optional
+     * argument index ({@code 3$}), flags ({@code -#+ 0,(}), width, precision and a
+     * trailing conversion letter (covers {@code %s}, {@code %d}, {@code %n}, {@code %1$s}, …).
      */
-    public static final Pattern CORRECT_PLACEHOLDER_PATTERN = Pattern.compile("%s");
+    private static final Pattern FORMAT_DIRECTIVE =
+        Pattern.compile("%%|%(?:\\d+\\$)?[-#+ 0,(]*\\d*(?:\\.\\d+)?[a-zA-Z]");
 
     /**
-     * Pattern for incorrect placeholders:
-     * - {} from SLF4J
-     * - %d, %f, %i, %o, %b, %x, %X, %e, %E, %g, %G from printf
+     * The single correct CUI placeholder.
      */
-    public static final Pattern INCORRECT_PLACEHOLDER_PATTERN =
-        Pattern.compile("\\{}|%[dfiobxXeEgG]");
+    private static final String CORRECT_PLACEHOLDER = "%s";
+
+    /**
+     * The SLF4J placeholder that must be rewritten to {@code %s}.
+     */
+    private static final String SLF4J_PLACEHOLDER = "{}";
 
     private PlaceholderValidationUtil() {
         // Utility class
@@ -58,41 +71,66 @@ public final class PlaceholderValidationUtil {
         if (message == null) {
             return false;
         }
-        return INCORRECT_PLACEHOLDER_PATTERN.matcher(message).find();
+        if (message.contains(SLF4J_PLACEHOLDER)) {
+            return true;
+        }
+        Matcher matcher = FORMAT_DIRECTIVE.matcher(message);
+        while (matcher.find()) {
+            String directive = matcher.group();
+            if (!"%%".equals(directive) && !CORRECT_PLACEHOLDER.equals(directive)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
-     * Corrects placeholder patterns in a message by replacing them with %s.
+     * Corrects placeholder patterns in a message by replacing them with {@code %s}.
+     * SLF4J {@code {}} and every printf directive other than {@code %s}/{@code %%} become
+     * {@code %s}; {@code %s} and the {@code %%} escape are preserved.
      *
      * @param message the message to correct
-     * @return the corrected message with all placeholders replaced by %s
+     * @return the corrected message with all placeholders replaced by {@code %s}
      */
     @Nullable
     public static String correctPlaceholders(@Nullable String message) {
         if (message == null) {
             return null;
         }
-        return message.replace("{}", "%s")
-            .replaceAll("%[dfiobxXeEgG]", "%s");
+        // Replace SLF4J placeholders first; the resulting %s are then left untouched below.
+        String withoutSlf4j = message.replace(SLF4J_PLACEHOLDER, CORRECT_PLACEHOLDER);
+
+        Matcher matcher = FORMAT_DIRECTIVE.matcher(withoutSlf4j);
+        StringBuilder result = new StringBuilder();
+        while (matcher.find()) {
+            String directive = matcher.group();
+            String replacement = ("%%".equals(directive) || CORRECT_PLACEHOLDER.equals(directive))
+                ? directive
+                : CORRECT_PLACEHOLDER;
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(result);
+        return result.toString();
     }
 
     /**
-     * Counts the number of %s placeholders in a message.
+     * Counts the number of {@code %s} placeholders in a message. The literal-percent
+     * escape {@code %%} is consumed first, so the {@code s} in {@code "%%s"} is not counted.
      *
      * @param message the message to analyze
-     * @return the count of %s placeholders
+     * @return the count of {@code %s} placeholders
      */
     public static int countPlaceholders(@Nullable String message) {
         if (message == null) {
             return 0;
         }
-        Matcher matcher = CORRECT_PLACEHOLDER_PATTERN.matcher(message);
+        Matcher matcher = FORMAT_DIRECTIVE.matcher(message);
         int count = 0;
         while (matcher.find()) {
-            count++;
+            if (CORRECT_PLACEHOLDER.equals(matcher.group())) {
+                count++;
+            }
         }
         return count;
     }
-
-
 }

--- a/src/test/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipeTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipeTest.java
@@ -643,4 +643,88 @@ class CuiLoggerStandardsRecipeTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void shouldRenameQualifiedThisReference() {
+        rewriteRun(
+            java(
+                """
+                import de.cuioss.tools.logging.CuiLogger;
+
+                class Test {
+                    private static final CuiLogger log = new CuiLogger(Test.class);
+
+                    void method() {
+                        this.log.info("hello");
+                    }
+                }
+                """,
+                """
+                import de.cuioss.tools.logging.CuiLogger;
+
+                class Test {
+                    private static final CuiLogger LOGGER = new CuiLogger(Test.class);
+
+                    void method() {
+                        this.LOGGER.info("hello");
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void shouldRenameNonInvocationReference() {
+        rewriteRun(
+            java(
+                """
+                import de.cuioss.tools.logging.CuiLogger;
+
+                class Test {
+                    private static final CuiLogger log = new CuiLogger(Test.class);
+
+                    CuiLogger expose() {
+                        return log;
+                    }
+                }
+                """,
+                """
+                import de.cuioss.tools.logging.CuiLogger;
+
+                class Test {
+                    private static final CuiLogger LOGGER = new CuiLogger(Test.class);
+
+                    CuiLogger expose() {
+                        return LOGGER;
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void shouldNotRenameWhenLoggerNameCollisionExists() {
+        rewriteRun(
+            java(
+                """
+                import de.cuioss.tools.logging.CuiLogger;
+
+                class Test {
+                    private static final CuiLogger LOGGER = new CuiLogger(Test.class);
+                    private static final CuiLogger log = new CuiLogger(Test.class);
+                }
+                """,
+                """
+                import de.cuioss.tools.logging.CuiLogger;
+
+                class Test {
+                    private static final CuiLogger LOGGER = new CuiLogger(Test.class);
+                    /*~~(TODO: Rename logger to LOGGER (name already in use). Suppress: // cui-rewrite:disable CuiLoggerStandardsRecipe)~~>*/private static final CuiLogger log = new CuiLogger(Test.class);
+                }
+                """
+            )
+        );
+    }
 }

--- a/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeTest.java
@@ -1009,4 +1009,65 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
         );
     }
 
+    @Test
+    void detectGenericExceptionInMultiCatch() {
+        rewriteRun(
+            java(
+                """
+                class Test {
+                    void test() {
+                        try {
+                            doSomething();
+                        } catch (IllegalStateException | RuntimeException e) {
+                            e.printStackTrace();
+                        }
+                    }
+
+                    void doSomething() {
+                        // may throw
+                    }
+                }
+                """,
+                """
+                class Test {
+                    void test() {
+                        try {
+                            doSomething();
+                        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (IllegalStateException | RuntimeException e) {
+                            e.printStackTrace();
+                        }
+                    }
+
+                    void doSomething() {
+                        // may throw
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void allowSpecificExceptionsInMultiCatch() {
+        rewriteRun(
+            java(
+                """
+                class Test {
+                    void test() {
+                        try {
+                            doSomething();
+                        } catch (IllegalStateException | IllegalArgumentException e) {
+                            e.printStackTrace();
+                        }
+                    }
+
+                    void doSomething() {
+                        // may throw
+                    }
+                }
+                """
+            )
+        );
+    }
+
 }

--- a/src/test/java/de/cuioss/rewrite/logging/PlaceholderValidationUtilTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/PlaceholderValidationUtilTest.java
@@ -16,51 +16,91 @@
 package de.cuioss.rewrite.logging;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PlaceholderValidationUtilTest {
+
+    static Stream<Arguments> incorrectPlaceholderCases() {
+        return Stream.of(
+            // message, expectedIncorrect
+            Arguments.of("", false),
+            Arguments.of("Simple message", false),
+            Arguments.of("Message with %s placeholder", false),
+            Arguments.of("%s %s multiple", false),
+            Arguments.of("100%% done", false),
+            Arguments.of("50%%d escaped", false),
+            Arguments.of("Message with {} placeholder", true),
+            Arguments.of("{} {} multiple", true),
+            Arguments.of("Integer %d placeholder", true),
+            Arguments.of("Float %f placeholder", true),
+            Arguments.of("Boolean %b placeholder", true),
+            Arguments.of("Hex %x placeholder", true),
+            Arguments.of("Scientific %e placeholder", true),
+            Arguments.of("Mixed %s and {} placeholders", true),
+            Arguments.of("%s correct but %d incorrect", true),
+            // width / precision / flags / index / line-separator forms (previously missed)
+            Arguments.of("Width %5d", true),
+            Arguments.of("Precision %.2f", true),
+            Arguments.of("Padded %08x", true),
+            Arguments.of("Grouped %,d", true),
+            Arguments.of("Indexed %1$s", true),
+            Arguments.of("Newline %n", true)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("incorrectPlaceholderCases")
+    void hasIncorrectPlaceholders(String message, boolean expectedIncorrect) {
+        assertEquals(expectedIncorrect, PlaceholderValidationUtil.hasIncorrectPlaceholders(message));
+    }
 
     @Test
     void hasIncorrectPlaceholdersNull() {
         assertFalse(PlaceholderValidationUtil.hasIncorrectPlaceholders(null));
     }
 
-    @Test
-    void hasIncorrectPlaceholdersEmptyString() {
-        assertFalse(PlaceholderValidationUtil.hasIncorrectPlaceholders(""));
+    static Stream<Arguments> correctPlaceholderCases() {
+        return Stream.of(
+            // input, expected
+            Arguments.of("", ""),
+            Arguments.of("Simple message without placeholders", "Simple message without placeholders"),
+            Arguments.of("Message with %s placeholder", "Message with %s placeholder"),
+            Arguments.of("Message with {} placeholder", "Message with %s placeholder"),
+            Arguments.of("{} {} multiple", "%s %s multiple"),
+            Arguments.of("Integer %d placeholder", "Integer %s placeholder"),
+            Arguments.of("Float %f placeholder", "Float %s placeholder"),
+            Arguments.of("Hex %x placeholder", "Hex %s placeholder"),
+            Arguments.of("HEX %X placeholder", "HEX %s placeholder"),
+            Arguments.of("Octal %o placeholder", "Octal %s placeholder"),
+            Arguments.of("Mixed %s and {} placeholders", "Mixed %s and %s placeholders"),
+            Arguments.of("%s correct and %d also correct", "%s correct and %s also correct"),
+            Arguments.of("{} %d %f all converted", "%s %s %s all converted"),
+            // width / precision / flags / index / line-separator forms
+            Arguments.of("Width %5d", "Width %s"),
+            Arguments.of("Precision %.2f", "Precision %s"),
+            Arguments.of("Padded %08x", "Padded %s"),
+            Arguments.of("Grouped %,d", "Grouped %s"),
+            Arguments.of("Indexed %1$s", "Indexed %s"),
+            Arguments.of("Newline %n", "Newline %s"),
+            // %% escape must be preserved, not corrupted
+            Arguments.of("100%% done", "100%% done"),
+            Arguments.of("50%%d escaped", "50%%d escaped")
+        );
     }
 
-    @Test
-    void hasIncorrectPlaceholdersNoPlaceholders() {
-        assertFalse(PlaceholderValidationUtil.hasIncorrectPlaceholders("Simple message"));
-    }
-
-    @Test
-    void hasIncorrectPlaceholdersCorrectPlaceholders() {
-        assertFalse(PlaceholderValidationUtil.hasIncorrectPlaceholders("Message with %s placeholder"));
-        assertFalse(PlaceholderValidationUtil.hasIncorrectPlaceholders("%s %s multiple"));
-    }
-
-    @Test
-    void hasIncorrectPlaceholdersIncorrectCurlyBraces() {
-        assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("Message with {} placeholder"));
-        assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("{} {} multiple"));
-    }
-
-    @Test
-    void hasIncorrectPlaceholdersIncorrectFormatSpecifiers() {
-        assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("Integer %d placeholder"));
-        assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("Float %f placeholder"));
-        assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("Boolean %b placeholder"));
-        assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("Hex %x placeholder"));
-        assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("Scientific %e placeholder"));
-    }
-
-    @Test
-    void hasIncorrectPlaceholdersMixedPlaceholders() {
-        assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("Mixed %s and {} placeholders"));
-        assertTrue(PlaceholderValidationUtil.hasIncorrectPlaceholders("%s correct but %d incorrect"));
+    @ParameterizedTest
+    @MethodSource("correctPlaceholderCases")
+    void correctPlaceholders(String input, String expected) {
+        assertEquals(expected, PlaceholderValidationUtil.correctPlaceholders(input));
     }
 
     @Test
@@ -68,106 +108,33 @@ class PlaceholderValidationUtilTest {
         assertNull(PlaceholderValidationUtil.correctPlaceholders(null));
     }
 
-    @Test
-    void correctPlaceholdersEmptyString() {
-        assertEquals("", PlaceholderValidationUtil.correctPlaceholders(""));
+    static Stream<Arguments> countPlaceholderCases() {
+        return Stream.of(
+            // message, expectedCount
+            Arguments.of("", 0),
+            Arguments.of("Simple message", 0),
+            Arguments.of("Message with %s", 1),
+            Arguments.of("%s and %s", 2),
+            Arguments.of("%s %s %s", 3),
+            Arguments.of("%s%s", 2),
+            Arguments.of("100%% complete with %s", 1),
+            Arguments.of("100%% complete", 0),
+            Arguments.of("User %s logged in at %s with 100%% success rate: %s", 3),
+            // the s in an escaped percent must not be counted
+            Arguments.of("%%s", 0),
+            // an indexed directive is not a bare %s
+            Arguments.of("%1$s %s", 1)
+        );
     }
 
-    @Test
-    void correctPlaceholdersNoPlaceholders() {
-        String message = "Simple message without placeholders";
-        assertEquals(message, PlaceholderValidationUtil.correctPlaceholders(message));
-    }
-
-    @Test
-    void correctPlaceholdersAlreadyCorrect() {
-        String message = "Message with %s placeholder";
-        assertEquals(message, PlaceholderValidationUtil.correctPlaceholders(message));
-    }
-
-    @Test
-    void correctPlaceholdersReplaceCurlyBraces() {
-        assertEquals("Message with %s placeholder",
-            PlaceholderValidationUtil.correctPlaceholders("Message with {} placeholder"));
-        assertEquals("%s %s multiple",
-            PlaceholderValidationUtil.correctPlaceholders("{} {} multiple"));
-    }
-
-    @Test
-    void correctPlaceholdersReplaceFormatSpecifiers() {
-        assertEquals("Integer %s placeholder",
-            PlaceholderValidationUtil.correctPlaceholders("Integer %d placeholder"));
-        assertEquals("Float %s placeholder",
-            PlaceholderValidationUtil.correctPlaceholders("Float %f placeholder"));
-        assertEquals("Boolean %s placeholder",
-            PlaceholderValidationUtil.correctPlaceholders("Boolean %b placeholder"));
-        assertEquals("Hex %s placeholder",
-            PlaceholderValidationUtil.correctPlaceholders("Hex %x placeholder"));
-        assertEquals("HEX %s placeholder",
-            PlaceholderValidationUtil.correctPlaceholders("HEX %X placeholder"));
-        assertEquals("Scientific %s placeholder",
-            PlaceholderValidationUtil.correctPlaceholders("Scientific %e placeholder"));
-        assertEquals("SCIENTIFIC %s placeholder",
-            PlaceholderValidationUtil.correctPlaceholders("SCIENTIFIC %E placeholder"));
-        assertEquals("General %s placeholder",
-            PlaceholderValidationUtil.correctPlaceholders("General %g placeholder"));
-        assertEquals("GENERAL %s placeholder",
-            PlaceholderValidationUtil.correctPlaceholders("GENERAL %G placeholder"));
-        assertEquals("Integer %s placeholder",
-            PlaceholderValidationUtil.correctPlaceholders("Integer %i placeholder"));
-        assertEquals("Octal %s placeholder",
-            PlaceholderValidationUtil.correctPlaceholders("Octal %o placeholder"));
-    }
-
-    @Test
-    void correctPlaceholdersMixedPlaceholders() {
-        assertEquals("Mixed %s and %s placeholders",
-            PlaceholderValidationUtil.correctPlaceholders("Mixed %s and {} placeholders"));
-        assertEquals("%s correct and %s also correct",
-            PlaceholderValidationUtil.correctPlaceholders("%s correct and %d also correct"));
-        assertEquals("%s %s %s all converted",
-            PlaceholderValidationUtil.correctPlaceholders("{} %d %f all converted"));
+    @ParameterizedTest
+    @MethodSource("countPlaceholderCases")
+    void countPlaceholders(String message, int expectedCount) {
+        assertEquals(expectedCount, PlaceholderValidationUtil.countPlaceholders(message));
     }
 
     @Test
     void countPlaceholdersNull() {
         assertEquals(0, PlaceholderValidationUtil.countPlaceholders(null));
-    }
-
-    @Test
-    void countPlaceholdersEmptyString() {
-        assertEquals(0, PlaceholderValidationUtil.countPlaceholders(""));
-    }
-
-    @Test
-    void countPlaceholdersNoPlaceholders() {
-        assertEquals(0, PlaceholderValidationUtil.countPlaceholders("Simple message"));
-    }
-
-    @Test
-    void countPlaceholdersSinglePlaceholder() {
-        assertEquals(1, PlaceholderValidationUtil.countPlaceholders("Message with %s"));
-    }
-
-    @Test
-    void countPlaceholdersMultiplePlaceholders() {
-        assertEquals(2, PlaceholderValidationUtil.countPlaceholders("%s and %s"));
-        assertEquals(3, PlaceholderValidationUtil.countPlaceholders("%s %s %s"));
-    }
-
-    @Test
-    void countPlaceholdersConsecutivePlaceholders() {
-        assertEquals(2, PlaceholderValidationUtil.countPlaceholders("%s%s"));
-    }
-
-    @Test
-    void countPlaceholdersEscapedPercent() {
-        assertEquals(1, PlaceholderValidationUtil.countPlaceholders("100%% complete with %s"));
-        assertEquals(0, PlaceholderValidationUtil.countPlaceholders("100%% complete"));
-    }
-
-    @Test
-    void countPlaceholdersComplexPattern() {
-        assertEquals(3, PlaceholderValidationUtil.countPlaceholders("User %s logged in at %s with 100%% success rate: %s"));
     }
 }


### PR DESCRIPTION
## Summary

Behavioral correctness fixes in the recipe main sources, each with new tests. This is PR 2 of the review-26-07-04 fix plan (F-6, F-7, F-8, F-9, F-13).

### F-6 — Logger rename now covers all reference forms
`checkLoggerNaming` delegated reference rewriting to a hand-rolled path that only handled plain-identifier method-invocation selects, producing non-compiling code for `this.log.info(...)`, a logger passed as an argument, non-invocation references, or nested-class references. It now delegates the whole rename to `org.openrewrite.java.RenameVariable`, and guards against a name collision: when a `LOGGER` field already exists, the mis-named field is flagged instead of being renamed into a duplicate.

### F-7 — Generic exceptions in multi-catch
`catch (RuntimeException | IllegalStateException e)` has a `JavaType.MultiCatch` union type, for which `asFullyQualified` returns `null`, so the generic alternative slipped through. Each alternative is now inspected individually.

### F-8 — Placeholder detection overhaul
`PlaceholderValidationUtil` now scans real printf directives left-to-right. It detects width/precision/flag/index/`%n` forms (`%5d`, `%.2f`, `%08x`, `%,d`, `%1$s`, `%n`) that were previously missed, and consumes the `%%` escape first so `"%%d"` is no longer corrupted into `"%%s"` and the `s` in `"%%s"` is not counted as a placeholder.

### F-9 — Locale-safe casing
`LogLevel.fromMethodName` uses `Locale.ROOT` to avoid the Turkish dotted-I bug (`"info".toUpperCase()` → `"İNFO"`).

### F-13 — Modifier normalization scope
Documented that only visibility/static/final are normalized; extra modifiers (transient/volatile) keep their original relative order after `final`, consistent with the JLS.

### Tests
`./mvnw clean verify` → **259/259 tests pass** (was 220). Adds multi-catch, logger-reference-form and collision tests, and parameterizes `PlaceholderValidationUtilTest` with the new edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017LEJGXxb5huvHs78aUGA9o)_