### PR TITLE
docs: fix metadata, document JDK support and add CuiDefaults composite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 cui-open-rewrite is a Java library providing OpenRewrite recipes for cuioss projects. It helps automate Java modernization and code migration tasks.
 
-**Maven Coordinates**: `de.cuioss:cui-open-rewrite`
+**Maven Coordinates**: `de.cuioss.rewrite:cui-open-rewrite`
 
 ## Build Commands
 

--- a/README.adoc
+++ b/README.adoc
@@ -12,19 +12,26 @@ image:https://sonarcloud.io/api/project_badges/measure?project=cuioss_cui-open-r
 image:https://sonarcloud.io/api/project_badges/measure?project=cuioss_cui-open-rewrite&metric=coverage[Coverage,link=https://sonarcloud.io/summary/new_code?id=cuioss_cui-open-rewrite]
 
 
-https://cuioss.github.io/cui-java-module-template/about.html[Generated Documentation on github-pages]
+https://cuioss.github.io/cui-open-rewrite/about.html[Generated Documentation on github-pages]
 
 == What is it?
 
 Custom OpenRewrite recipes for CUI-OSS projects that enforce specific code formatting standards not available in existing OpenRewrite recipes.
 
+=== Requirements
+
+The recipes run on both JDK 21 and JDK 25. On JDK 21 the `rewrite-java-21` parser is used; on JDK 25 the `rewrite-java-25` parser is activated automatically via the `java25-parser` Maven profile.
+
 === Maven Coordinates
+
+Replace `${cui-open-rewrite.version}` below with the latest release (see the Maven Central badge above).
 
 [source,xml]
 ----
 <dependency>
     <groupId>de.cuioss.rewrite</groupId>
     <artifactId>cui-open-rewrite</artifactId>
+    <version>${cui-open-rewrite.version}</version>
 </dependency>
 ----
 

--- a/src/main/java/de/cuioss/rewrite/format/AnnotationNewlineFormat.java
+++ b/src/main/java/de/cuioss/rewrite/format/AnnotationNewlineFormat.java
@@ -35,6 +35,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Recipe that ensures type-, method- and field-level annotations are each placed on their own line.
+ *
+ * <p>Inline declarations such as {@code @Deprecated public class Foo} are reformatted so the
+ * annotation sits on a separate line from the declaration, improving readability and matching the
+ * CUI formatting standard. Classes without any modifier are left untouched due to OpenRewrite AST
+ * limitations.</p>
+ *
+ * <p>Suppression is supported via {@code // cui-rewrite:disable AnnotationNewlineFormat}.</p>
+ */
 public class AnnotationNewlineFormat extends Recipe {
 
     public static final String RECIPE_NAME = "AnnotationNewlineFormat";

--- a/src/main/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLogRecordPatternRecipe.java
@@ -37,6 +37,16 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
+/**
+ * Recipe that enforces the CUI {@code LogRecord} pattern per the CUI logging standards.
+ *
+ * <p>Use of a {@code LogRecord} template is mandatory for INFO/WARN/ERROR/FATAL logging and forbidden
+ * for DEBUG/TRACE (which must log directly). The recipe rewrites incorrect placeholders to {@code %s}
+ * in templates, converts zero-argument {@code LogRecord.format()} calls to the {@code LogRecord::format}
+ * method reference, and flags — with {@code SearchResult} markers — calls that violate the pattern.</p>
+ *
+ * <p>Suppression is supported via {@code // cui-rewrite:disable CuiLogRecordPatternRecipe}.</p>
+ */
 public class CuiLogRecordPatternRecipe extends Recipe {
 
     private static final String CUI_LOGGER_TYPE = "de.cuioss.tools.logging.CuiLogger";

--- a/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/CuiLoggerStandardsRecipe.java
@@ -41,6 +41,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Recipe that enforces the CUI logging standards on {@code CuiLogger} usage.
+ *
+ * <p>It auto-fixes logger field naming (to {@code LOGGER}) and modifiers (to
+ * {@code private static final}), rewrites {@code {}} / printf placeholders to {@code %s}, and moves
+ * an exception argument to the first position for {@code error}/{@code warn} calls. It flags — with
+ * {@code SearchResult} markers — {@code System.out}/{@code System.err} usage and placeholder/parameter
+ * count mismatches.</p>
+ *
+ * <p>Suppression is supported via {@code // cui-rewrite:disable CuiLoggerStandardsRecipe}.</p>
+ */
 public class CuiLoggerStandardsRecipe extends Recipe {
 
     private static final String CUI_LOGGER_TYPE = "de.cuioss.tools.logging.CuiLogger";

--- a/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
@@ -47,7 +47,7 @@ import java.util.Set;
  */
 public class InvalidExceptionUsageRecipe extends Recipe {
 
-    private static final String RECIPE_NAME = "InvalidExceptionUsageRecipe";
+    public static final String RECIPE_NAME = "InvalidExceptionUsageRecipe";
 
     private static final Set<String> GENERIC_EXCEPTION_TYPES = Set.of(
         "java.lang.Exception",

--- a/src/main/java/de/cuioss/rewrite/util/package-info.java
+++ b/src/main/java/de/cuioss/rewrite/util/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Shared utilities supporting the CUI OpenRewrite recipes.
+ *
+ * <p>This package provides the cross-cutting building blocks used by the recipes:
+ * {@link de.cuioss.rewrite.util.BaseSuppressionVisitor} and
+ * {@link de.cuioss.rewrite.util.RecipeSuppressionUtil} for {@code // cui-rewrite:disable} suppression
+ * handling, {@link de.cuioss.rewrite.util.PathExclusionVisitor} for excluding generated sources under
+ * {@code target/}/{@code build/}, and {@link de.cuioss.rewrite.util.RecipeMarkerUtil} for creating and
+ * detecting the {@code SearchResult} task markers.</p>
+ */
+@NullMarked
+package de.cuioss.rewrite.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/resources/META-INF/rewrite/cui-defaults.yml
+++ b/src/main/resources/META-INF/rewrite/cui-defaults.yml
@@ -1,0 +1,31 @@
+#
+# Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: de.cuioss.rewrite.CuiDefaults
+displayName: CUI defaults
+description: >-
+  Applies the CUI OpenRewrite recipes in the correct order. AutoFormat runs first (its bundled
+  NormalizeFormat would otherwise undo the annotation formatting), followed by AnnotationNewlineFormat
+  and the logging standards recipes. This encodes the ordering caveat once so consumers do not have to.
+tags:
+  - CUI
+recipeList:
+  - org.openrewrite.java.format.AutoFormat
+  - de.cuioss.rewrite.format.AnnotationNewlineFormat
+  - de.cuioss.rewrite.logging.CuiLoggerStandardsRecipe
+  - de.cuioss.rewrite.logging.CuiLogRecordPatternRecipe
+  - de.cuioss.rewrite.logging.InvalidExceptionUsageRecipe

--- a/src/test/java/de/cuioss/rewrite/CuiDefaultsRecipeTest.java
+++ b/src/test/java/de/cuioss/rewrite/CuiDefaultsRecipeTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.rewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Recipe;
+import org.openrewrite.config.Environment;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Verifies that the declarative {@code de.cuioss.rewrite.CuiDefaults} composite recipe is discoverable
+ * on the classpath and lists the CUI recipes in the documented order (AutoFormat first).
+ */
+class CuiDefaultsRecipeTest {
+
+    private static final String RECIPE_NAME = "de.cuioss.rewrite.CuiDefaults";
+
+    @Test
+    void shouldLoadCompositeInDocumentedOrder() {
+        Environment environment = Environment.builder()
+            .scanRuntimeClasspath("de.cuioss.rewrite")
+            .build();
+
+        Recipe recipe = environment.activateRecipes(RECIPE_NAME);
+        assertNotNull(recipe);
+        assertFalse(recipe.getDescription().isBlank(), "description must not be blank");
+
+        List<String> orderedNames = recipe.getRecipeList().stream()
+            .map(Recipe::getName)
+            .toList();
+
+        assertEquals(
+            List.of(
+                "org.openrewrite.java.format.AutoFormat",
+                "de.cuioss.rewrite.format.AnnotationNewlineFormat",
+                "de.cuioss.rewrite.logging.CuiLoggerStandardsRecipe",
+                "de.cuioss.rewrite.logging.CuiLogRecordPatternRecipe",
+                "de.cuioss.rewrite.logging.InvalidExceptionUsageRecipe"
+            ),
+            orderedNames
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Documentation and metadata polish. This is PR 5 (final content PR) of the review-26-07-04 fix plan (F-18, F-19, F-20, F-21).

### F-18 — CLAUDE.md coordinates
Corrected to `de.cuioss.rewrite:cui-open-rewrite`.

### F-19 — README
- The github-pages link now points at this project (`https://cuioss.github.io/cui-open-rewrite/about.html`) instead of the template.
- The Maven usage snippet defines the `${cui-open-rewrite.version}` placeholder with a note.
- Added a Requirements section documenting that the recipes run on JDK 21 and 25.

### F-20 — Javadoc / package-info / visibility
- Added class-level javadoc to `AnnotationNewlineFormat`, `CuiLoggerStandardsRecipe` and `CuiLogRecordPatternRecipe` (only `InvalidExceptionUsageRecipe` had one).
- Added `package-info.java` for `de.cuioss.rewrite.util` (`@NullMarked`, matching the other packages).
- Made `InvalidExceptionUsageRecipe.RECIPE_NAME` `public` for consistency — it is the documented suppression token.

### F-21 — Declarative composite recipe
Added `de.cuioss.rewrite.CuiDefaults` (`META-INF/rewrite/cui-defaults.yml`) which runs `AutoFormat` first, then the CUI recipes, encoding the ordering caveat once so consumers do not have to activate four recipes individually and risk getting the order wrong. Added a test asserting the composite loads from the classpath and lists the recipes in the documented order.

### Verification
`./mvnw clean verify` → **261/261 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017LEJGXxb5huvHs78aUGA9o)_