### PR TITLE
fix: emit InvalidExceptionUsageRecipe catch marker on its own line above catch

### DIFF
--- a/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
@@ -126,8 +126,6 @@ public class InvalidExceptionUsageRecipe extends Recipe {
         }
 
         @Override
-        @SuppressWarnings("java:S2637")
-        // SearchResult.found() never returns null for non-null input
         public J.Try.Catch visitCatch(J.Try.Catch catchBlock, ExecutionContext ctx) {
             J.Try.Catch c = super.visitCatch(catchBlock, ctx);
 
@@ -149,10 +147,29 @@ public class InvalidExceptionUsageRecipe extends Recipe {
                 if (RecipeMarkerUtil.hasTaskComment(c, taskMessage, getCursor()) || RecipeMarkerUtil.hasSearchResultMarker(c)) {
                     return c;
                 }
-                return SearchResult.found(c, taskMessage);
+                // Place the advisory marker on its own line above the catch (rather than inline
+                // before the catch keyword) so the catch line itself is left untouched, avoiding
+                // the coverage/blame churn an inline marker causes.
+                return RecipeMarkerUtil.withOwnLineCatchMarker(c, taskMessage, catchIndent());
             }
 
             return c;
+        }
+
+        /**
+         * Returns the indentation (leading whitespace) of the enclosing try/catch construct, used
+         * to align the own-line catch marker with the closing brace of the try block.
+         *
+         * @return the indentation string, or an empty string when it cannot be resolved
+         */
+        private String catchIndent() {
+            J.Try tryStatement = getCursor().firstEnclosing(J.Try.class);
+            if (tryStatement == null) {
+                return "";
+            }
+            String whitespace = tryStatement.getPrefix().getWhitespace();
+            int lastNewline = whitespace.lastIndexOf('\n');
+            return lastNewline >= 0 ? whitespace.substring(lastNewline + 1) : "";
         }
 
         /**

--- a/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
+++ b/src/main/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipe.java
@@ -158,18 +158,15 @@ public class InvalidExceptionUsageRecipe extends Recipe {
 
         /**
          * Returns the indentation (leading whitespace) of the enclosing try/catch construct, used
-         * to align the own-line catch marker with the closing brace of the try block.
+         * to align the own-line catch marker with the closing brace of the try block. A catch is
+         * always nested inside a try, so the enclosing {@link J.Try} is always present.
          *
-         * @return the indentation string, or an empty string when it cannot be resolved
+         * @return the indentation string (the trailing segment of the try's leading whitespace
+         *         after the last newline; the full whitespace when it carries no newline)
          */
         private String catchIndent() {
-            J.Try tryStatement = getCursor().firstEnclosing(J.Try.class);
-            if (tryStatement == null) {
-                return "";
-            }
-            String whitespace = tryStatement.getPrefix().getWhitespace();
-            int lastNewline = whitespace.lastIndexOf('\n');
-            return lastNewline >= 0 ? whitespace.substring(lastNewline + 1) : "";
+            String whitespace = getCursor().firstEnclosingOrThrow(J.Try.class).getPrefix().getWhitespace();
+            return whitespace.substring(whitespace.lastIndexOf('\n') + 1);
         }
 
         /**

--- a/src/main/java/de/cuioss/rewrite/util/RecipeMarkerUtil.java
+++ b/src/main/java/de/cuioss/rewrite/util/RecipeMarkerUtil.java
@@ -23,6 +23,7 @@ import org.openrewrite.java.tree.TextComment;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.marker.SearchResult;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -59,6 +60,10 @@ public final class RecipeMarkerUtil {
      * path ({@link #hasTaskComment}) recognizes it on subsequent runs and the idempotence guard
      * still fires.</p>
      *
+     * <p>Any comments already present in the catch prefix (developer notes, unrelated suppression
+     * comments) are preserved — the new marker is appended after them rather than replacing them,
+     * keeping the recipe non-destructive to unrelated AST content.</p>
+     *
      * @param catchBlock  the catch to mark
      * @param taskMessage the advisory task message to embed as a multiline comment
      * @param indent      the indentation (leading whitespace) of the enclosing try/catch construct
@@ -67,7 +72,9 @@ public final class RecipeMarkerUtil {
     public static J.Try.Catch withOwnLineCatchMarker(J.Try.Catch catchBlock, String taskMessage, String indent) {
         String newlineIndent = "\n" + indent;
         Comment marker = new TextComment(true, taskMessage, newlineIndent, Markers.EMPTY);
-        return catchBlock.withPrefix(Space.build(newlineIndent, List.of(marker)));
+        List<Comment> comments = new ArrayList<>(catchBlock.getPrefix().getComments());
+        comments.add(marker);
+        return catchBlock.withPrefix(Space.build(newlineIndent, comments));
     }
 
     /**

--- a/src/main/java/de/cuioss/rewrite/util/RecipeMarkerUtil.java
+++ b/src/main/java/de/cuioss/rewrite/util/RecipeMarkerUtil.java
@@ -19,7 +19,11 @@ import org.openrewrite.Cursor;
 import org.openrewrite.java.tree.Comment;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TextComment;
+import org.openrewrite.marker.Markers;
 import org.openrewrite.marker.SearchResult;
+
+import java.util.List;
 
 /**
  * Utility class for managing OpenRewrite recipe markers and task comments.
@@ -40,6 +44,30 @@ public final class RecipeMarkerUtil {
      */
     public static String createTaskMessage(String action, String recipeName) {
         return "TODO: %s. Suppress: // cui-rewrite:disable %s".formatted(action, recipeName);
+    }
+
+    /**
+     * Builds a copy of the given catch with the advisory task marker placed on its own line
+     * above the {@code catch} keyword.
+     *
+     * <p>The catch element's leading {@link Space} — the prefix between the try-block's closing
+     * {@code }} and the {@code catch} keyword — is reshaped to {@code newline + indent}, followed
+     * by the marker as a multiline block comment, followed by {@code newline + indent} before the
+     * {@code catch} keyword. This keeps the {@code catch} line itself untouched (apart from
+     * indentation), avoiding the coverage/blame churn an inline marker would cause. Because the
+     * marker is a multiline comment carried in the catch prefix, the existing duplicate-detection
+     * path ({@link #hasTaskComment}) recognizes it on subsequent runs and the idempotence guard
+     * still fires.</p>
+     *
+     * @param catchBlock  the catch to mark
+     * @param taskMessage the advisory task message to embed as a multiline comment
+     * @param indent      the indentation (leading whitespace) of the enclosing try/catch construct
+     * @return a copy of {@code catchBlock} whose prefix carries the own-line marker comment
+     */
+    public static J.Try.Catch withOwnLineCatchMarker(J.Try.Catch catchBlock, String taskMessage, String indent) {
+        String newlineIndent = "\n" + indent;
+        Comment marker = new TextComment(true, taskMessage, newlineIndent, Markers.EMPTY);
+        return catchBlock.withPrefix(Space.build(newlineIndent, List.of(marker)));
     }
 
     /**

--- a/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeSuppressionTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeSuppressionTest.java
@@ -100,7 +100,9 @@ class InvalidExceptionUsageRecipeSuppressionTest implements RewriteTest {
                     void method() {
                         try {
                             doSomething();
-                        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
+                        }
+                        /*TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+                        catch (RuntimeException e) {
                             handleException(e);
                         }
                     }
@@ -232,7 +234,9 @@ class InvalidExceptionUsageRecipeSuppressionTest implements RewriteTest {
                         try {
                             doSomething();
                             // cui-rewrite:disable SomeOtherRecipe
-                        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+                        }
+                        /*TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+                        catch (Exception e) {
                             handleException(e);
                         }
                     }

--- a/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeTest.java
@@ -113,6 +113,46 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
     }
 
     @Test
+    void preservesExistingCatchPrefixComment() {
+        rewriteRun(
+            java(
+                """
+                class Test {
+                    void test() {
+                        try {
+                            doSomething();
+                        } /* keep me */ catch (RuntimeException e) {
+                            e.printStackTrace();
+                        }
+                    }
+
+                    void doSomething() {
+                        // Something that might throw RuntimeException
+                    }
+                }
+                """,
+                """
+                class Test {
+                    void test() {
+                        try {
+                            doSomething();
+                        }
+                        /* keep me */ /*TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+                        catch (RuntimeException e) {
+                            e.printStackTrace();
+                        }
+                    }
+
+                    void doSomething() {
+                        // Something that might throw RuntimeException
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    @Test
     void detectCatchingThrowable() {
         rewriteRun(
             java(

--- a/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeTest.java
+++ b/src/test/java/de/cuioss/rewrite/logging/InvalidExceptionUsageRecipeTest.java
@@ -56,7 +56,9 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     void test() {
                         try {
                             doSomething();
-                        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+                        }
+                        /*TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+                        catch (Exception e) {
                             e.printStackTrace();
                         }
                     }
@@ -94,7 +96,9 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     void test() {
                         try {
                             doSomething();
-                        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
+                        }
+                        /*TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+                        catch (RuntimeException e) {
                             e.printStackTrace();
                         }
                     }
@@ -132,7 +136,9 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     void test() {
                         try {
                             doSomething();
-                        } /*~~(TODO: Catch specific not Throwable. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Throwable t) {
+                        }
+                        /*TODO: Catch specific not Throwable. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+                        catch (Throwable t) {
                             t.printStackTrace();
                         }
                     }
@@ -249,7 +255,9 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                             doSomething();
                         } catch (IOException e) {
                             // Handle specific exception
-                        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+                        }
+                        /*TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+                        catch (Exception e) {
                             // Generic catch as fallback
                         }
                     }
@@ -344,10 +352,14 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                         try {
                             try {
                                 doSomething();
-                            } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException re) {
+                            }
+                            /*TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+                            catch (RuntimeException re) {
                                 /*~~(TODO: Throw specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new Exception("Wrapping", re);
                             }
-                        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+                        }
+                        /*TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+                        catch (Exception e) {
                             e.printStackTrace();
                         }
                     }
@@ -392,7 +404,9 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                         Supplier<String> supplier = () -> {
                             try {
                                 return doSomething();
-                            } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+                            }
+                            /*TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+                            catch (Exception e) {
                                 /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException(e);
                             }
                         };
@@ -514,7 +528,7 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     void test() {
                         handleException(new Exception("Parameter case"));
                     }
-                    
+
                     void handleException(Exception e) {
                         // Handle exception
                     }
@@ -525,7 +539,7 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     void test() {
                         handleException(/*~~(TODO: Use specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/new Exception("Parameter case"));
                     }
-                    
+
                     void handleException(Exception e) {
                         // Handle exception
                     }
@@ -591,7 +605,9 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     void test() {
                         try {
                             doSomething();
-                        } /*~~(TODO: Catch specific not Throwable. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Throwable t) {
+                        }
+                        /*TODO: Catch specific not Throwable. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+                        catch (Throwable t) {
                             /*~~(TODO: Throw specific not Throwable. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new Throwable("Wrapping", t);
                         }
                     }
@@ -629,7 +645,9 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     static {
                         try {
                             initialize();
-                        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+                        }
+                        /*TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+                        catch (Exception e) {
                             /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException("Static init failed", e);
                         }
                     }
@@ -668,7 +686,9 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     void test() {
                         try {
                             doSomething();
-                        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+                        }
+                        /*TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+                        catch (Exception e) {
                             e.printStackTrace();
                         }
                     }
@@ -977,7 +997,9 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     void test() {
                         try (FileInputStream fis = new FileInputStream("test.txt")) {
                             // Use resource
-                        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+                        }
+                        /*TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+                        catch (Exception e) {
                             /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException(e);
                         }
                     }
@@ -1011,7 +1033,9 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     void test() {
                         try {
                             doSomething();
-                        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (IllegalStateException | RuntimeException e) {
+                        }
+                        /*TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+                        catch (IllegalStateException | RuntimeException e) {
                             e.printStackTrace();
                         }
                     }
@@ -1063,7 +1087,9 @@ class InvalidExceptionUsageRecipeTest implements RewriteTest {
                     void test() {
                         try {
                             doSomething();
-                        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+                        }
+                        /*TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+                        catch (Exception e) {
                             e.printStackTrace();
                         }
                     }


### PR DESCRIPTION
## Summary

Fixes #105.

`InvalidExceptionUsageRecipe` emitted its advisory TODO/suppression marker as an **inline** block comment on the same physical line as `catch (RuntimeException …)`. That mutated an executable source line, so git-blame + SonarCloud attributed the `catch` line as changed "new code" — dragging the new-code coverage gate below threshold for what is a comment-only injection.

This change relocates the catch marker onto its **own standalone line immediately above** the `catch` statement, so a non-coverable comment line carries the advisory while the `catch` line is left untouched.

### Before

```java
} /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/ catch (RuntimeException failure) {
```

### After

```java
}
/*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/
catch (RuntimeException failure) {
```

## What changed

- **`InvalidExceptionUsageRecipe.visitCatch`** — the marker is now injected into the catch element's leading `Space` (own line above `catch`) instead of via an inline `SearchResult.found(...)`. `visitThrow` / `visitNewClass` emission is unchanged.
- **`RecipeMarkerUtil`** — added the own-line catch-marker builder; the relocated marker stays a multiline block comment, so the existing `hasTaskComment → hasTaskCommentInCatchBlock → containsTaskInSpace` (`Comment::isMultiline`) idempotence path still recognizes it. No detection widening was required.
- **Tests (TDD)** — `InvalidExceptionUsageRecipeTest` (11 catch-marker expectations + 1 input fixture) and `InvalidExceptionUsageRecipeSuppressionTest` (2 catch-marker expectations) were updated **first** to the own-line placement, then the recipe was changed to make them pass.

## Why

A standalone comment line is not a coverable line and does not change the `catch` line's blame, so Sonar/JaCoCo no longer attribute an uncovered executable line to a comment-only mutation, and the new-code coverage gate is no longer perturbed. The line-scoped `cui-rewrite:disable` suppression mechanism and recipe idempotence are fully preserved.

## Verification

- `./mvnw clean verify` passes; all `InvalidExceptionUsageRecipe` tests green with the catch marker rendered on its own line.
- Idempotence tests (`preventDuplicateMarkersOnCatch`, `shouldNotAddDuplicateWhenCommentAlreadyExists`, `shouldBeIdempotentAcrossMultipleCycles`) still pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer, standalone TODO markers above flagged `catch` statements for invalid generic exception usage.
  * Improved marker indentation across different code layouts.

* **Bug Fixes**
  * Updated exception usage findings to produce consistently formatted suppression guidance.
  * Preserved marker information to help prevent duplicate advisories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->