### PR TITLE
chore(release): prepare release 1.4.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,8 +2,8 @@ name: cui-open-rewrite
 description: CUI OpenRewrite recipes for Java modernization
 
 release:
-  current-version: 1.3.1
-  next-version: 1.3.2-SNAPSHOT
+  current-version: 1.4.0
+  next-version: 1.4.1-SNAPSHOT
   create-github-release: true
 
 maven-build:


### PR DESCRIPTION
Bump current-version to 1.4.0, next-version to 1.4.1-SNAPSHOT. Triggers the automated Release workflow on merge.